### PR TITLE
GH-9: Fix DslRecipientListRouter recipients order

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.0.BUILD-SNAPSHOT
+version=1.0.1.BUILD-SNAPSHOT

--- a/src/main/java/org/springframework/integration/dsl/DslRecipientListRouter.java
+++ b/src/main/java/org/springframework/integration/dsl/DslRecipientListRouter.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import org.springframework.beans.BeansException;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.dsl.support.MessageChannelReference;
+import org.springframework.integration.dsl.support.tuple.Tuple2;
+import org.springframework.integration.dsl.support.tuple.Tuples;
 import org.springframework.integration.filter.ExpressionEvaluatingSelector;
 import org.springframework.integration.router.RecipientListRouter;
 import org.springframework.messaging.MessageChannel;
@@ -35,6 +37,8 @@ import org.springframework.util.StringUtils;
  */
 class DslRecipientListRouter extends RecipientListRouter {
 
+	private final List<Tuple2<?, ?>> recipients = new ArrayList<Tuple2<?, ?>>();
+
 	private final Map<String, String> expressionRecipientMap = new HashMap<String, String>();
 
 	private final Map<String, MessageSelector> selectorRecipientMap = new HashMap<String, MessageSelector>();
@@ -45,58 +49,54 @@ class DslRecipientListRouter extends RecipientListRouter {
 			new HashMap<MessageChannel, MessageSelector>();
 
 	void add(String channelName, String expression) {
-		this.expressionRecipientMap.put(channelName, expression);
+		this.recipients.add(Tuples.of(channelName, expression));
 	}
 
 	void add(String channelName, MessageSelector selector) {
-		this.selectorRecipientMap.put(channelName, selector);
+		this.recipients.add(Tuples.of(channelName, selector));
 	}
 
 	void add(MessageChannel channel, String expression) {
-		this.channelExpressionRecipientMap.put(channel, expression);
+		this.recipients.add(Tuples.of(channel, expression));
 	}
 
 	void add(MessageChannel channel, MessageSelector selector) {
-		this.channelSelectorRecipientMap.put(channel, selector);
+		this.recipients.add(Tuples.of(channel, selector));
 	}
 
 	@Override
 	public void onInit() throws Exception {
-		for (Map.Entry<String, String> recipient : this.expressionRecipientMap.entrySet()) {
-			ExpressionEvaluatingSelector selector = null;
-			String expression = recipient.getValue();
-			if (StringUtils.hasText(expression)) {
-				selector = new ExpressionEvaluatingSelector(expression);
-				selector.setBeanFactory(this.getBeanFactory());
+		List<Recipient> recipients = new ArrayList<Recipient>(this.recipients.size());
+
+		for (Tuple2<?, ?> recipient : this.recipients) {
+			if (recipient.getT1() instanceof String) {
+				recipients.add(new DslRecipient(new MessageChannelReference((String) recipient.getT1()),
+						populateRecipientSelector(recipient.getT2())));
 			}
-			this.selectorRecipientMap.put(recipient.getKey(), selector);
-		}
-
-		for (Map.Entry<MessageChannel, String> recipient : this.channelExpressionRecipientMap.entrySet()) {
-			ExpressionEvaluatingSelector selector = null;
-			String expression = recipient.getValue();
-			if (StringUtils.hasText(expression)) {
-				selector = new ExpressionEvaluatingSelector(expression);
-				selector.setBeanFactory(this.getBeanFactory());
+			else {
+				recipients.add(new Recipient((MessageChannel) recipient.getT1(),
+						populateRecipientSelector(recipient.getT2())));
 			}
-			this.channelSelectorRecipientMap.put(recipient.getKey(), selector);
-		}
-
-		List<Recipient> recipients = new ArrayList<Recipient>(this.selectorRecipientMap.size()
-				+ this.channelSelectorRecipientMap.size());
-
-		for (Map.Entry<String, MessageSelector> entry : selectorRecipientMap.entrySet()) {
-			recipients.add(new DslRecipient(new MessageChannelReference(entry.getKey()), entry.getValue()));
-		}
-
-		for (Map.Entry<MessageChannel, MessageSelector> entry : channelSelectorRecipientMap.entrySet()) {
-			recipients.add(new Recipient(entry.getKey(), entry.getValue()));
 		}
 
 		setRecipients(recipients);
 		super.onInit();
 	}
 
+	private MessageSelector populateRecipientSelector(Object recipientSelector) {
+		if (recipientSelector instanceof String) {
+			String expression = (String) recipientSelector;
+			if (StringUtils.hasText(expression)) {
+				ExpressionEvaluatingSelector selector = new ExpressionEvaluatingSelector(expression);
+				selector.setBeanFactory(getBeanFactory());
+				return selector;
+			}
+		}
+		else {
+			return (MessageSelector) recipientSelector;
+		}
+		return null;
+	}
 
 	class DslRecipient extends Recipient {
 

--- a/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -24,6 +24,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.dsl.core.ComponentsRegistration;
 import org.springframework.integration.router.RecipientListRouter;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
 /**
@@ -38,6 +39,17 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 
 	RecipientListRouterSpec() {
 		super(new DslRecipientListRouter());
+	}
+
+	/**
+	 * Adds a recipient channel that always will be selected.
+	 * @param channelName the channel name.
+	 * @return the router spec.
+	 */
+	public RecipientListRouterSpec recipient(String channelName) {
+		Assert.hasText(channelName);
+		((DslRecipientListRouter) this.target).add(channelName, (MessageSelector) null);
+		return _this();
 	}
 
 	/**
@@ -61,6 +73,41 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	public RecipientListRouterSpec recipient(String channelName, MessageSelector selector) {
 		Assert.hasText(channelName);
 		((DslRecipientListRouter) this.target).add(channelName, selector);
+		return _this();
+	}
+
+	/**
+	 * Adds a recipient channel that always will be selected.
+	 * @param channel the recipient channel.
+	 * @return the router spec.
+	 */
+	public RecipientListRouterSpec recipient(MessageChannel channel) {
+		Assert.notNull(channel);
+		((DslRecipientListRouter) this.target).add(channel, (MessageSelector) null);
+		return _this();
+	}
+
+	/**
+	 * Adds a recipient channel that will be selected if the the expression evaluates to 'true'.
+	 * @param channel the recipient channel.
+	 * @param expression the expression.
+	 * @return the router spec.
+	 */
+	public RecipientListRouterSpec recipient(MessageChannel channel, String expression) {
+		Assert.notNull(channel);
+		((DslRecipientListRouter) this.target).add(channel, expression);
+		return _this();
+	}
+
+	/**
+	 * Adds a recipient channel that will be selected if the the selector's accept method returns 'true'.
+	 * @param channel the recipient channel.
+	 * @param selector the selector.
+	 * @return the router spec.
+	 */
+	public RecipientListRouterSpec recipient(MessageChannel channel, MessageSelector selector) {
+		Assert.notNull(channel);
+		((DslRecipientListRouter) this.target).add(channel, selector);
 		return _this();
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
@@ -41,6 +41,9 @@ public class AmqpOutboundEndpointSpec extends MessageHandlerSpec<AmqpOutboundEnd
 		this.expectReply = expectReply;
 		this.endpoint.setExpectReply(expectReply);
 		this.endpoint.setHeaderMapper(this.headerMapper);
+		if (expectReply) {
+			this.endpoint.setRequiresReply(true);
+		}
 	}
 
 	public AmqpOutboundEndpointSpec headerMapper(AmqpHeaderMapper headerMapper) {
@@ -102,7 +105,7 @@ public class AmqpOutboundEndpointSpec extends MessageHandlerSpec<AmqpOutboundEnd
 	}
 
 	public AmqpOutboundEndpointSpec mappedReplyHeaders(String... headers) {
-		Assert.isTrue(expectReply, "'mappedReplyHeaders' can be applied on for gateway");
+		Assert.isTrue(expectReply, "'mappedReplyHeaders' can be applied only for gateway");
 		this.headerMapper.setReplyHeaderNames(headers);
 		return this;
 	}

--- a/src/main/java/org/springframework/integration/dsl/file/FileWritingMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/file/FileWritingMessageHandlerSpec.java
@@ -55,28 +55,31 @@ public class FileWritingMessageHandlerSpec
 	}
 
 	FileWritingMessageHandlerSpec expectReply(boolean expectReply) {
-		target.setExpectReply(expectReply);
+		this.target.setExpectReply(expectReply);
+		if (expectReply) {
+			this.target.setRequiresReply(true);
+		}
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec autoCreateDirectory(boolean autoCreateDirectory) {
-		target.setAutoCreateDirectory(autoCreateDirectory);
+		this.target.setAutoCreateDirectory(autoCreateDirectory);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec temporaryFileSuffix(String temporaryFileSuffix) {
-		target.setTemporaryFileSuffix(temporaryFileSuffix);
+		this.target.setTemporaryFileSuffix(temporaryFileSuffix);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec fileExistsMode(FileExistsMode fileExistsMode) {
-		target.setFileExistsMode(fileExistsMode);
+		this.target.setFileExistsMode(fileExistsMode);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec fileNameGenerator(FileNameGenerator fileNameGenerator) {
 		this.fileNameGenerator = fileNameGenerator;
-		target.setFileNameGenerator(fileNameGenerator);
+		this.target.setFileNameGenerator(fileNameGenerator);
 		return _this();
 	}
 
@@ -90,12 +93,12 @@ public class FileWritingMessageHandlerSpec
 
 
 	public FileWritingMessageHandlerSpec deleteSourceFiles(boolean deleteSourceFiles) {
-		target.setDeleteSourceFiles(deleteSourceFiles);
+		this.target.setDeleteSourceFiles(deleteSourceFiles);
 		return _this();
 	}
 
 	public FileWritingMessageHandlerSpec charset(String charset) {
-		target.setCharset(charset);
+		this.target.setCharset(charset);
 		return _this();
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
@@ -40,6 +40,7 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 
 	protected RemoteFileOutboundGatewaySpec(AbstractRemoteFileOutboundGateway<F> outboundGateway) {
 		this.target = outboundGateway;
+		this.target.setRequiresReply(true);
 	}
 
 	public S options(String options) {

--- a/src/main/java/org/springframework/integration/dsl/jms/JmsOutboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/JmsOutboundGatewaySpec.java
@@ -42,6 +42,7 @@ public class JmsOutboundGatewaySpec extends MessageHandlerSpec<JmsOutboundGatewa
 
 	JmsOutboundGatewaySpec(ConnectionFactory connectionFactory) {
 		this.target = new JmsOutboundGateway();
+		this.target.setRequiresReply(true);
 		this.target.setConnectionFactory(connectionFactory);
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration-java-dsl/issues/9

Since `RecipientListRouter` assumes that recipients should receive message in that order in which they have been added,
the logic with `Map` for each recipient type in the `DslRecipientListRouter` isn't correct.
- Change it to the `List<Tuple2<?, ?>>` and do appropriate logic during iteration saving an order.
- Add `requiresReply = true` for those gateway `Spec`s, which are based on those XML components which provide that option as `true` by default.
- Add more `.recipient()` methods to the `RecipientListRouterSpec`
