### PR TITLE
INTEXT-132: Fix for bean overrides

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,8 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 			return processStandardIntegrationFlow((StandardIntegrationFlow) bean, beanName);
 		}
 		else if (bean instanceof IntegrationFlow) {
-			return processIntegrationFlowImpl((IntegrationFlow) bean, beanName);
+			processIntegrationFlowImpl((IntegrationFlow) bean, beanName);
+			return bean;
 		}
 		return bean;
 	}

--- a/src/test/java/org/springframework/integration/dsl/test/amqp/AmqpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/amqp/AmqpTests.java
@@ -32,9 +32,11 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
 import org.springframework.integration.dsl.IntegrationFlows;
@@ -116,7 +118,8 @@ public class AmqpTests {
 	}
 
 	@Configuration
-	@EnableAutoConfiguration
+	@EnableIntegration
+	@Import(RabbitAutoConfiguration.class)
 	public static class ContextConfiguration {
 
 		@Autowired

--- a/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.test.flowservices;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlowDefinition;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Artem Bilan
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class FlowServiceTests {
+
+	@Autowired
+	@Qualifier("flowServiceTests.MyFlow.input")
+	private MessageChannel input;
+
+	@Autowired(required = false)
+	private MyFlow myFlow;
+
+	@Test
+	public void testFlowService() {
+		assertNotNull(this.myFlow);
+		QueueChannel replyChannel = new QueueChannel();
+		this.input.send(MessageBuilder.withPayload("foo").setReplyChannel(replyChannel).build());
+		Message<?> receive = replyChannel.receive(1000);
+		assertNotNull(receive);
+		assertEquals("FOO", receive.getPayload());
+	}
+
+	@Configuration
+	@EnableIntegration
+	@ComponentScan
+	public static class ContextConfiguration {
+
+	}
+
+	@Component
+	public static class MyFlow implements IntegrationFlow {
+
+		@Override
+		public void accept(IntegrationFlowDefinition<?> f) {
+			f.<String, String>transform(String::toUpperCase);
+		}
+
+	}
+
+}

--- a/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,30 +39,27 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.core.Pollers;
 import org.springframework.integration.dsl.ftp.Ftp;
-import org.springframework.integration.dsl.sftp.Sftp;
-import org.springframework.integration.dsl.test.sftp.TestSftpServer;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.ftp.session.DefaultFtpSessionFactory;
 import org.springframework.integration.scheduling.PollerMetadata;
-import org.springframework.integration.sftp.session.DefaultSftpSessionFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -76,7 +73,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Artem Bilan
  */
-@ContextConfiguration(initializers = ConfigFileApplicationContextInitializer.class)
+@ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
 public class FtpTests {
@@ -185,8 +182,7 @@ public class FtpTests {
 	}
 
 	@Configuration
-	@Import(TestFtpServer.class)
-	@EnableAutoConfiguration
+	@Import({TestFtpServer.class, IntegrationAutoConfiguration.class})
 	@IntegrationComponentScan
 	public static class ContextConfiguration {
 

--- a/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,11 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.jdbc.InvalidResultSetAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -68,7 +70,8 @@ public class JdbcTests {
 	}
 
 	@Configuration
-	@EnableAutoConfiguration
+	@EnableIntegration
+	@Import(DataSourceAutoConfiguration.class)
 	public static class ContextConfiguration {
 
 		@Autowired

--- a/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,12 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.channel.ChannelInterceptorAware;
@@ -158,7 +160,7 @@ public class JmsTests {
 	}
 
 	@Configuration
-	@EnableAutoConfiguration
+	@Import({ActiveMQAutoConfiguration.class, IntegrationAutoConfiguration.class})
 	@IntegrationComponentScan
 	@ComponentScan
 	public static class ContextConfiguration {

--- a/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.test.ConfigFileApplicationContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +50,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.channel.MessageChannels;
@@ -72,7 +75,7 @@ import com.jcraft.jsch.ChannelSftp;
 /**
  * @author Artem Bilan
  */
-@ContextConfiguration(initializers = ConfigFileApplicationContextInitializer.class)
+@ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
 public class SftpTests {
@@ -182,8 +185,7 @@ public class SftpTests {
 	}
 
 	@Configuration
-	@Import(TestSftpServer.class)
-	@EnableAutoConfiguration
+	@Import({TestSftpServer.class, IntegrationAutoConfiguration.class})
 	@IntegrationComponentScan
 	public static class ContextConfiguration {
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-132

We can do something like this

```
@Component
public class MyFlow implements IntegrationFlow
```
But `IntegrationFlowBeanPostProcessor` overrides that bean just with `StandardIntegrationFlow` after process. This is wrong behavior.

In addition optimize test do not use **all** auto-configuration stuff from `classpath`.

**Cherry-pick to 1.0.x**