### PR TITLE
INTEXT-171: Lambdas - Improve Stacktrace

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/LambdaMessageProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/LambdaMessageProcessor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.dsl;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
@@ -124,6 +125,9 @@ class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFactoryAwa
 
 		try {
 			return this.method.invoke(this.target, args);
+		}
+		catch(InvocationTargetException e) {
+			throw new MessageHandlingException(message, e.getCause());
 		}
 		catch (Exception e) {
 			throw new MessageHandlingException(message, e);

--- a/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
+++ b/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.dsl;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.integration.dsl.support.GenericHandler;
+import org.springframework.messaging.support.GenericMessage;
+
+
+/**
+ * @author Gary Russell
+ * @since 1.1.0
+ *
+ */
+public class LambdaMessageProcessorTests {
+
+	@Test
+	public void testException() {
+		try {
+			handle ((m, h) -> 1 / 0);
+			fail("Expected exception");
+		}
+		catch (Exception e) {
+			assertThat(e.getCause(), instanceOf(ArithmeticException.class));
+		}
+	}
+
+	private void handle(GenericHandler<?> h) {
+		LambdaMessageProcessor lmp = new LambdaMessageProcessor(h, String.class);
+		lmp.setBeanFactory(mock(BeanFactory.class));
+		lmp.processMessage(new GenericMessage<>("foo"));
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-171

Remove `InvocationTargetException` from the stack trace.