### PR TITLE
GH-35: Make compatible with IO-1.1.x

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/file/FileTransferringMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/file/FileTransferringMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,10 @@ public abstract class FileTransferringMessageHandlerSpec<F, S extends FileTransf
 		extends MessageHandlerSpec<S, FileTransferringMessageHandler<F>>
 		implements ComponentsRegistration {
 
+	private final static Constructor<?> FILE_EXISTS_MODE_CONSTRUCTOR =
+			ClassUtils.getConstructorIfAvailable(FileTransferringMessageHandler.class, RemoteFileTemplate.class,
+					FileExistsMode.class);
+
 	private FileNameGenerator fileNameGenerator;
 
 	private DefaultFileNameGenerator defaultFileNameGenerator;
@@ -58,10 +62,7 @@ public abstract class FileTransferringMessageHandlerSpec<F, S extends FileTransf
 	@SuppressWarnings("unchecked")
 	protected FileTransferringMessageHandlerSpec(RemoteFileTemplate<F> remoteFileTemplate,
 			FileExistsMode fileExistsMode) {
-		Constructor<?> fileExistsModeConstructor =
-				ClassUtils.getConstructorIfAvailable(FileTransferringMessageHandler.class, RemoteFileTemplate.class,
-						FileExistsMode.class);
-		if (fileExistsModeConstructor == null) {
+		if (FILE_EXISTS_MODE_CONSTRUCTOR == null) {
 			logger.warn("The 'FileExistsMode' constructor argument for the 'FileTransferringMessageHandler' is " +
 					"available since Spring Integration 4.1. Will be ignored for previous versions.");
 			this.target = new FileTransferringMessageHandler<F>(remoteFileTemplate);
@@ -69,7 +70,7 @@ public abstract class FileTransferringMessageHandlerSpec<F, S extends FileTransf
 		else {
 			try {
 				this.target =
-						(FileTransferringMessageHandler<F>) fileExistsModeConstructor.newInstance(remoteFileTemplate,
+						(FileTransferringMessageHandler<F>) FILE_EXISTS_MODE_CONSTRUCTOR.newInstance(remoteFileTemplate,
 								fileExistsMode);
 			}
 			catch (Exception e) {

--- a/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,17 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 		return mputFilter(new SimplePatternFileListFilter(pattern));
 	}
 
+	/**
+	 * @param regex the RegExp to filter files
+	 * @return the current Spec
+	 * @deprecated in favor of {@link #regexMputFilter(String)}
+	 */
+	@Deprecated
 	public S regexMpuFilter(String regex) {
+		return regexMputFilter(regex);
+	}
+
+	public S regexMputFilter(String regex) {
 		return mputFilter(new RegexPatternFileListFilter(regex));
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration-java-dsl/issues/35

* Add reflection constructor extraction in the `MailSendingMessageHandlerSpec`
for the `MailSendingMessageHandler`, since its sources has
been changed since SI-4.1.3 (https://jira.spring.io/browse/INT-3623)
* Optimize reflection logic for the `FileTransferringMessageHandlerSpec`
* Fix typo in the `RemoteFileOutboundGatewaySpec` method deprecating existing and introducing a new one

Tested against IO like:
```
./gradlew clean springIoCheck -PplatformVersion=1.1.3.BUILD-SNAPSHOT -PJDK8_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/
```
As well as as normal build.