### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 		maven { url 'http://repo.spring.io/plugins-release' }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
+		classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
 	}
 }
 
@@ -27,8 +27,13 @@ repositories {
 if (project.hasProperty('platformVersion')) {
 	apply plugin: 'spring-io'
 
-	dependencies {
-		springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+	dependencyManagement {
+		springIoTestRuntime {
+			imports {
+				mavenBom "io.spring.platform:platform-bom:${platformVersion}"
+			}
+
+		}
 	}
 }
 


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring Integration Java DSL's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in whatever version of Spring Integration Java DSL is going to be in Spring IO Platform 2.0. I guess that may be 1.1 given our earlier discussions around Reactor, etc. If you've got any questions, please let me know.