### PR TITLE
GH-22, INTEXT-184, INTEXT-188, INTEXT-128

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ jacoco {
 
 dependencies {
 	compile("org.springframework.integration:spring-integration-core:$springIntegrationVersion")
+	compile "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
 
 	['spring-integration-amqp'
 	 , 'spring-integration-event'
@@ -123,8 +124,6 @@ dependencies {
 	}
 	compile("javax.jms:jms-api:$jmsApiVersion", provided)
 	compile("javax.mail:javax.mail-api:$mailVersion", provided)
-
-	compile("org.reactivestreams:reactive-streams:$reactiveStreamsVersion", optional)
 
 	testCompile "org.springframework.integration:spring-integration-test:$springIntegrationVersion"
 	testCompile("org.springframework.boot:spring-boot-starter:$springBootVersion") {

--- a/src/main/java/org/springframework/integration/dsl/AggregatorSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/AggregatorSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,25 @@
 
 package org.springframework.integration.dsl;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.ExpressionEvaluatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.MessageGroupProcessor;
 import org.springframework.integration.aggregator.MethodInvokingMessageGroupProcessor;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.util.Assert;
 
 /**
  * A {@link CorrelationHandlerSpec} for an {@link AggregatingMessageHandler}.
- *
  * @author Artem Bilan
  */
 public class AggregatorSpec extends CorrelationHandlerSpec<AggregatorSpec, AggregatingMessageHandler> {
 
-	private MessageGroupProcessor outputProcessor = new DefaultAggregatingMessageGroupProcessor();
-
-	private boolean expireGroupsUponCompletion;
-
 	AggregatorSpec() {
+		super(new InternalAggregatingMessageHandler());
 	}
 
 	/**
@@ -41,9 +42,10 @@ public class AggregatorSpec extends CorrelationHandlerSpec<AggregatorSpec, Aggre
 	 * and {@link org.springframework.integration.aggregator.MethodInvokingReleaseStrategy} using the target
 	 * object which should have methods annotated appropriately for each function.
 	 * Also set the output processor.
-	 * @param target the target object.
+	 * @param target     the target object.
 	 * @param methodName The method name for the output processor (or 'null' in which case, the
-	 * target object must have an {@link org.springframework.integration.annotation.Aggregator} annotation).
+	 *                   target object must have an {@link org.springframework.integration.annotation.Aggregator}
+	 *                   annotation).
 	 * @return the handler spec.
 	 */
 	public AggregatorSpec processor(Object target, String methodName) {
@@ -70,7 +72,8 @@ public class AggregatorSpec extends CorrelationHandlerSpec<AggregatorSpec, Aggre
 	 * @return the aggregator spec.
 	 */
 	public AggregatorSpec outputProcessor(MessageGroupProcessor outputProcessor) {
-		this.outputProcessor = outputProcessor;
+		Assert.notNull(outputProcessor);
+		((InternalAggregatingMessageHandler) this.target.getT2()).getOutputProcessor().setDelegate(outputProcessor);
 		return _this();
 	}
 
@@ -80,15 +83,44 @@ public class AggregatorSpec extends CorrelationHandlerSpec<AggregatorSpec, Aggre
 	 * @see AggregatingMessageHandler#setExpireGroupsUponCompletion(boolean)
 	 */
 	public AggregatorSpec expireGroupsUponCompletion(boolean expireGroupsUponCompletion) {
-		this.expireGroupsUponCompletion = expireGroupsUponCompletion;
+		this.target.getT2().setExpireGroupsUponCompletion(expireGroupsUponCompletion);
 		return _this();
 	}
 
-	@Override
-	protected AggregatingMessageHandler doGet() {
-		AggregatingMessageHandler handler = new AggregatingMessageHandler(this.outputProcessor);
-		handler.setExpireGroupsUponCompletion(this.expireGroupsUponCompletion);
-		return this.configure(handler);
+
+	private static class InternalAggregatingMessageHandler extends AggregatingMessageHandler {
+
+		public InternalAggregatingMessageHandler() {
+			super(new MessageGroupProcessorWrapper());
+		}
+
+		@Override
+		protected MessageGroupProcessorWrapper getOutputProcessor() {
+			return (MessageGroupProcessorWrapper) super.getOutputProcessor();
+		}
+
+	}
+
+	private static class MessageGroupProcessorWrapper implements MessageGroupProcessor, BeanFactoryAware {
+
+		private MessageGroupProcessor delegate = new DefaultAggregatingMessageGroupProcessor();
+
+		public void setDelegate(MessageGroupProcessor delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Object processMessageGroup(MessageGroup group) {
+			return this.delegate.processMessageGroup(group);
+		}
+
+		@Override
+		public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+			if (this.delegate instanceof BeanFactoryAware) {
+				((BeanFactoryAware) this.delegate).setBeanFactory(beanFactory);
+			}
+		}
+
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -1693,6 +1693,35 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	/**
 	 * Populate the provided {@link AbstractMessageSplitter} to the current integration
 	 * flow position.
+	 * @param splitterMessageHandlerSpec the {@link MessageHandlerSpec} to populate.
+	 * @param <S> the {@link AbstractMessageSplitter}
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @see SplitterEndpointSpec
+	 * @since 1.1
+	 */
+	public <S extends AbstractMessageSplitter> B split(MessageHandlerSpec<?, S> splitterMessageHandlerSpec) {
+		return split(splitterMessageHandlerSpec, (Consumer<SplitterEndpointSpec<S>>) null);
+	}
+
+	/**
+	 * Populate the provided {@link AbstractMessageSplitter} to the current integration
+	 * flow position.
+	 * @param splitterMessageHandlerSpec the {@link MessageHandlerSpec} to populate.
+	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
+	 * @param <S> the {@link AbstractMessageSplitter}
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @see SplitterEndpointSpec
+	 * @since 1.1
+	 */
+	public <S extends AbstractMessageSplitter> B split(MessageHandlerSpec<?, S> splitterMessageHandlerSpec,
+	               Consumer<SplitterEndpointSpec<S>> endpointConfigurer) {
+		Assert.notNull(splitterMessageHandlerSpec);
+		return split(splitterMessageHandlerSpec.get(), endpointConfigurer);
+	}
+
+	/**
+	 * Populate the provided {@link AbstractMessageSplitter} to the current integration
+	 * flow position.
 	 * @param splitter the {@link AbstractMessageSplitter} to populate.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 * @see SplitterEndpointSpec

--- a/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -1045,7 +1045,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 			serviceActivatingHandler = new ServiceActivatingHandler(new LambdaMessageProcessor(handler, payloadType));
 		}
 		else {
-			serviceActivatingHandler = new ServiceActivatingHandler(handler);
+			serviceActivatingHandler = new ServiceActivatingHandler(handler, "handle");
 		}
 		return this.handle(serviceActivatingHandler, endpointConfigurer);
 	}
@@ -1812,18 +1812,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
 	public B resequence() {
-		return this.resequence((Consumer<GenericEndpointSpec<ResequencingMessageHandler>>) null);
-	}
-
-	/**
-	 * Populate the {@link ResequencingMessageHandler} with default options.
-	 * In addition accept options for the integration endpoint using {@link GenericEndpointSpec}.
-	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
-	 * @return the current {@link IntegrationFlowDefinition}.
-	 * @see GenericEndpointSpec
-	 */
-	public B resequence(Consumer<GenericEndpointSpec<ResequencingMessageHandler>> endpointConfigurer) {
-		return this.handle(new ResequencerSpec().get(), endpointConfigurer);
+		return resequence(null);
 	}
 
 	/**
@@ -1833,20 +1822,42 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * <pre class="code">
 	 * {@code
 	 *  .resequence(r -> r.releasePartialSequences(true).correlationExpression("'foo'"),
-	 *             e -> e.applySequence(false))
+	 *             e -> e.phase(100))
 	 * }
 	 * </pre>
 	 * @param resequencerConfigurer the {@link Consumer} to provide {@link ResequencingMessageHandler} options.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 * @see GenericEndpointSpec
+	 * @deprecated since 1.1 in favor of {@link #resequence(Consumer)}
 	 */
+	@Deprecated
 	public B resequence(Consumer<ResequencerSpec> resequencerConfigurer,
 			Consumer<GenericEndpointSpec<ResequencingMessageHandler>> endpointConfigurer) {
 		Assert.notNull(resequencerConfigurer);
 		ResequencerSpec spec = new ResequencerSpec();
 		resequencerConfigurer.accept(spec);
-		return this.handle(spec.get(), endpointConfigurer);
+		return handle(spec.get().getT2(), endpointConfigurer);
+	}
+
+	/**
+	 * Populate the {@link ResequencingMessageHandler} with provided options from {@link ResequencerSpec}.
+	 * In addition accept options for the integration endpoint using {@link GenericEndpointSpec}.
+	 * Typically used with a Java 8 Lambda expression:
+	 * <pre class="code">
+	 * {@code
+	 *  .resequence(r -> r.releasePartialSequences(true)
+	 *                    .correlationExpression("'foo'")
+	 *                    .phase(100))
+	 * }
+	 * </pre>
+	 * @param resequencer the {@link Consumer} to provide {@link ResequencingMessageHandler} options.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @see ResequencerSpec
+	 * @since 1.1
+	 */
+	public B resequence(Consumer<ResequencerSpec> resequencer) {
+		return register(new ResequencerSpec(), resequencer);
 	}
 
 	/**
@@ -1854,18 +1865,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
 	public B aggregate() {
-		return aggregate((Consumer<GenericEndpointSpec<AggregatingMessageHandler>>) null);
-	}
-
-	/**
-	 * Populate the {@link AggregatingMessageHandler} with default options.
-	 * In addition accept options for the integration endpoint using {@link GenericEndpointSpec}.
-	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
-	 * @return the current {@link IntegrationFlowDefinition}.
-	 * @see GenericEndpointSpec
-	 */
-	public B aggregate(Consumer<GenericEndpointSpec<AggregatingMessageHandler>> endpointConfigurer) {
-		return handle(new AggregatorSpec().get(), endpointConfigurer);
+		return aggregate(null);
 	}
 
 	/**
@@ -1882,13 +1882,35 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 * @see GenericEndpointSpec
+	 * @deprecated since 1.1 in favor of {@link #aggregate(Consumer)}
 	 */
+	@Deprecated
 	public B aggregate(Consumer<AggregatorSpec> aggregatorConfigurer,
 			Consumer<GenericEndpointSpec<AggregatingMessageHandler>> endpointConfigurer) {
 		Assert.notNull(aggregatorConfigurer);
 		AggregatorSpec spec = new AggregatorSpec();
 		aggregatorConfigurer.accept(spec);
-		return this.handle(spec.get(), endpointConfigurer);
+		return this.handle(spec.get().getT2(), endpointConfigurer);
+	}
+
+	/**
+	 * Populate the {@link AggregatingMessageHandler} with provided options from {@link AggregatorSpec}.
+	 * In addition accept options for the integration endpoint using {@link GenericEndpointSpec}.
+	 * Typically used with a Java 8 Lambda expression:
+	 * <pre class="code">
+	 * {@code
+	 *  .aggregate(a -> a.correlationExpression("1")
+	 *                   .releaseStrategy(g -> g.size() == 25)
+	 *                   .phase(100))
+	 * }
+	 * </pre>
+	 * @param aggregator the {@link Consumer} to provide {@link AggregatingMessageHandler} options.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @see AggregatorSpec
+	 * @since 1.1
+	 */
+	public B aggregate(Consumer<AggregatorSpec> aggregator) {
+		return register(new AggregatorSpec(), aggregator);
 	}
 
 	/**

--- a/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -1694,6 +1694,18 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * Populate the provided {@link AbstractMessageSplitter} to the current integration
 	 * flow position.
 	 * @param splitter the {@link AbstractMessageSplitter} to populate.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @see SplitterEndpointSpec
+	 * @since 1.1
+	 */
+	public B split(AbstractMessageSplitter splitter) {
+		return split(splitter, (Consumer<SplitterEndpointSpec<AbstractMessageSplitter>>) null);
+	}
+
+	/**
+	 * Populate the provided {@link AbstractMessageSplitter} to the current integration
+	 * flow position.
+	 * @param splitter the {@link AbstractMessageSplitter} to populate.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
 	 * @param <S> the {@link AbstractMessageSplitter}
 	 * @return the current {@link IntegrationFlowDefinition}.

--- a/src/main/java/org/springframework/integration/dsl/ResequencerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/ResequencerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,8 @@ import org.springframework.integration.aggregator.ResequencingMessageHandler;
  */
 public class ResequencerSpec extends CorrelationHandlerSpec<ResequencerSpec, ResequencingMessageHandler> {
 
-	private final ResequencingMessageHandler resequencingMessageHandler =
-			new ResequencingMessageHandler(new ResequencingMessageGroupProcessor());
-
 	ResequencerSpec() {
+		super(new ResequencingMessageHandler(new ResequencingMessageGroupProcessor()));
 	}
 
 	/**
@@ -36,13 +34,8 @@ public class ResequencerSpec extends CorrelationHandlerSpec<ResequencerSpec, Res
 	 * @see ResequencingMessageHandler#setReleasePartialSequences(boolean)
 	 */
 	public ResequencerSpec releasePartialSequences(boolean releasePartialSequences) {
-		this.resequencingMessageHandler.setReleasePartialSequences(releasePartialSequences);
+		this.target.getT2().setReleasePartialSequences(releasePartialSequences);
 		return _this();
-	}
-
-	@Override
-	protected ResequencingMessageHandler doGet() {
-		return this.configure(this.resequencingMessageHandler);
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/file/FileSplitterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/file/FileSplitterSpec.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.file;
+
+import java.nio.charset.Charset;
+
+import org.springframework.integration.dsl.core.MessageHandlerSpec;
+import org.springframework.integration.file.splitter.FileSplitter;
+import org.springframework.util.Assert;
+
+/**
+ * The {@link MessageHandlerSpec} for the {@link FileSplitter}.
+ * @author Artem Bilan
+ * @since 1.1
+ */
+public class FileSplitterSpec extends MessageHandlerSpec<FileSplitterSpec, FileSplitter> {
+
+	private final FileSplitter fileSplitter;
+
+	FileSplitterSpec() {
+		this(true);
+	}
+
+	FileSplitterSpec(boolean iterator) {
+		this(iterator, false);
+	}
+
+	FileSplitterSpec(boolean iterator, boolean markers) {
+		this.fileSplitter = new FileSplitter(iterator, markers);
+	}
+
+	public FileSplitterSpec charset(String charset) {
+		Assert.hasText(charset);
+		return charset(Charset.forName(charset));
+	}
+
+	public FileSplitterSpec charset(Charset charset) {
+		this.fileSplitter.setCharset(charset);
+		return _this();
+	}
+
+	@Override
+	protected FileSplitter doGet() {
+		return this.fileSplitter;
+	}
+
+}

--- a/src/main/java/org/springframework/integration/dsl/file/Files.java
+++ b/src/main/java/org/springframework/integration/dsl/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.springframework.integration.dsl.support.Function;
 import org.springframework.messaging.Message;
 
 /**
+ * The Spring Integration File components Factory.
+ *
  * @author Artem Bilan
  */
 public abstract class Files {
@@ -62,6 +64,37 @@ public abstract class Files {
 
 	public static TailAdapterSpec tailAdapter(File file) {
 		return new TailAdapterSpec().file(file);
+	}
+
+	/**
+	 * The {@link FileSplitterSpec} builder factory method with default arguments.
+	 * @return the {@link FileSplitterSpec} builder.
+	 * @since 1.1
+	 */
+	public static FileSplitterSpec splitter() {
+		return splitter(true);
+	}
+
+	/**
+	 * The {@link FileSplitterSpec} builder factory method with {@code iterator} flag specified.
+	 * @param iterator the {@code boolean} flag to specify the {@code iterator} mode or not.
+	 * @return the {@link FileSplitterSpec} builder.
+	 * @since 1.1
+	 */
+	public static FileSplitterSpec splitter(boolean iterator) {
+		return splitter(iterator, false);
+	}
+
+	/**
+	 * The {@link FileSplitterSpec} builder factory method with {@code iterator} and {@code markers}
+	 * flags specified.
+	 * @param iterator the {@code boolean} flag to specify the {@code iterator} mode or not.
+	 * @param markers true to emit start of file/end of file marker messages before/after the data.
+	 * @return the {@link FileSplitterSpec} builder.
+	 * @since 1.1
+	 */
+	public static FileSplitterSpec splitter(boolean iterator, boolean markers) {
+		return new FileSplitterSpec(iterator, markers);
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/file/RemoteFileOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.io.File;
 import org.springframework.integration.dsl.core.MessageHandlerSpec;
 import org.springframework.integration.dsl.support.Function;
 import org.springframework.integration.dsl.support.FunctionExpression;
+import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.filters.RegexPatternFileListFilter;
 import org.springframework.integration.file.filters.SimplePatternFileListFilter;
@@ -34,9 +35,9 @@ import org.springframework.util.Assert;
 public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutboundGatewaySpec<F, S>>
 		extends MessageHandlerSpec<S, AbstractRemoteFileOutboundGateway<F>> {
 
-	private FileListFilter<F> filter;
+	private CompositeFileListFilter<F> filter;
 
-	private FileListFilter<File> mputFilter;
+	private CompositeFileListFilter<File> mputFilter;
 
 	protected RemoteFileOutboundGatewaySpec(AbstractRemoteFileOutboundGateway<F> outboundGateway) {
 		this.target = outboundGateway;
@@ -89,10 +90,19 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 	}
 
 	public S filter(FileListFilter<F> filter) {
-		Assert.isNull(this.filter,
-				"The 'filter' (" + this.filter + ") is already configured for the: " + this);
-		this.filter = filter;
-		this.target.setFilter(filter);
+		if (this.filter == null) {
+			if (filter instanceof CompositeFileListFilter) {
+				this.filter = (CompositeFileListFilter<F>) filter;
+			}
+			else {
+				this.filter = new CompositeFileListFilter<F>();
+				this.filter.addFilter(filter);
+			}
+			this.target.setFilter(this.filter);
+		}
+		else {
+			this.filter.addFilter(filter);
+		}
 		return _this();
 	}
 
@@ -101,10 +111,19 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 	public abstract S regexFileNameFilter(String regex);
 
 	public S mputFilter(FileListFilter<File> filter) {
-		Assert.isNull(this.mputFilter,
-				"The 'filter' (" + this.mputFilter + ") is already configured for the: " + this);
-		this.mputFilter = filter;
-		this.target.setMputFilter(filter);
+		if (this.mputFilter == null) {
+			if (filter instanceof CompositeFileListFilter) {
+				this.mputFilter = (CompositeFileListFilter<File>) filter;
+			}
+			else {
+				this.mputFilter = new CompositeFileListFilter<File>();
+				this.mputFilter.addFilter(filter);
+			}
+			this.target.setMputFilter(this.mputFilter);
+		}
+		else {
+			this.mputFilter.addFilter(filter);
+		}
 		return _this();
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/ftp/Ftp.java
+++ b/src/main/java/org/springframework/integration/dsl/ftp/Ftp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Comparator;
 
 import org.apache.commons.net.ftp.FTPFile;
 
+import org.springframework.integration.file.remote.MessageSessionCallback;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -67,6 +68,52 @@ public abstract class Ftp {
 	public static FtpOutboundGatewaySpec outboundGateway(SessionFactory<FTPFile> sessionFactory,
 			String command, String expression) {
 		return new FtpOutboundGatewaySpec(new FtpOutboundGateway(sessionFactory, command, expression));
+	}
+
+	/**
+	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the remoteFilePath.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate} to be based on.
+	 * @param command the command to perform on the FTP.
+	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link FtpOutboundGatewaySpec}
+	 * @see RemoteFileTemplate
+	 * @since 1.1
+	 */
+	public static FtpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate,
+	             AbstractRemoteFileOutboundGateway.Command command, String expression) {
+		return outboundGateway(remoteFileTemplate, command.getCommand(), expression);
+	}
+
+	/**
+	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the remoteFilePath.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate} to be based on.
+	 * @param command the command to perform on the FTP.
+	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link FtpOutboundGatewaySpec}
+	 * @see RemoteFileTemplate
+	 * @since 1.1
+	 */
+	public static FtpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate,
+	                                                      String command, String expression) {
+		return new FtpOutboundGatewaySpec(new FtpOutboundGateway(remoteFileTemplate, command, expression));
+	}
+
+
+
+	/**
+	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link MessageSessionCallback}.
+	 * @param sessionFactory the {@link SessionFactory} to connect to.
+	 * @param messageSessionCallback the {@link MessageSessionCallback} to perform SFTP operation(s)
+	 *                               with the {@code Message} context.
+	 * @return the {@link FtpOutboundGatewaySpec}
+	 * @see MessageSessionCallback
+	 * @since 1.1
+	 */
+	public static FtpOutboundGatewaySpec outboundGateway(SessionFactory<FTPFile> sessionFactory,
+	                    MessageSessionCallback<FTPFile, ?> messageSessionCallback) {
+		return new FtpOutboundGatewaySpec(new FtpOutboundGateway(sessionFactory, messageSessionCallback));
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/sftp/Sftp.java
+++ b/src/main/java/org/springframework/integration/dsl/sftp/Sftp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.dsl.sftp;
 import java.io.File;
 import java.util.Comparator;
 
+import org.springframework.integration.file.remote.MessageSessionCallback;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -67,6 +68,50 @@ public abstract class Sftp {
 	public static SftpOutboundGatewaySpec outboundGateway(SessionFactory<ChannelSftp.LsEntry> sessionFactory,
 			String command, String expression) {
 		return new SftpOutboundGatewaySpec(new SftpOutboundGateway(sessionFactory, command, expression));
+	}
+
+	/**
+	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the remoteFilePath.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate} to be based on.
+	 * @param command the command to perform on the SFTP.
+	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link SftpOutboundGatewaySpec}
+	 * @see RemoteFileTemplate
+	 * @since 1.1
+	 */
+	public static SftpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate,
+			AbstractRemoteFileOutboundGateway.Command command, String expression) {
+		return outboundGateway(remoteFileTemplate, command.getCommand(), expression);
+	}
+
+	/**
+	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the remoteFilePath.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate} to be based on.
+	 * @param command the command to perform on the SFTP.
+	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link SftpOutboundGatewaySpec}
+	 * @see RemoteFileTemplate
+	 * @since 1.1
+	 */
+	public static SftpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate,
+			String command, String expression) {
+		return new SftpOutboundGatewaySpec(new SftpOutboundGateway(remoteFileTemplate, command, expression));
+	}
+
+	/**
+	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link MessageSessionCallback}.
+	 * @param sessionFactory the {@link SessionFactory} to connect to.
+	 * @param messageSessionCallback the {@link MessageSessionCallback} to perform SFTP operation(s)
+	 *                               with the {@code Message} context.
+	 * @return the {@link SftpOutboundGatewaySpec}
+	 * @see MessageSessionCallback
+	 * @since 1.1
+	 */
+	public static SftpOutboundGatewaySpec outboundGateway(SessionFactory<ChannelSftp.LsEntry> sessionFactory,
+	       MessageSessionCallback<ChannelSftp.LsEntry, ?> messageSessionCallback) {
+		return new SftpOutboundGatewaySpec(new SftpOutboundGateway(sessionFactory, messageSessionCallback));
 	}
 
 }

--- a/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
@@ -25,9 +25,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +48,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.config.EnableIntegration;
@@ -54,6 +58,7 @@ import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageProducers;
 import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.core.Pollers;
+import org.springframework.integration.dsl.file.Files;
 import org.springframework.integration.dsl.support.Transformers;
 import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.integration.file.FileHeaders;
@@ -115,6 +120,10 @@ public class FileTests {
 	@Autowired
 	@Qualifier("fileWritingResultChannel")
 	private PollableChannel fileWritingResultChannel;
+
+	@Autowired
+	@Qualifier("fileSplittingResultChannel")
+	private PollableChannel fileSplittingResultChannel;
 
 	@Test
 	public void testFileHandler() throws Exception {
@@ -201,6 +210,21 @@ public class FileTests {
 		assertEquals(payload, fileContent);
 	}
 
+	@Test
+	public void testFileSplitterFlow() throws Exception {
+		FileOutputStream file = new FileOutputStream(new File(tmpDir.getRoot(), "foo.tmp"));
+		file.write(("HelloWorld\näöüß").getBytes(Charset.defaultCharset()));
+		file.flush();
+		file.close();
+
+		Message<?> receive = this.fileSplittingResultChannel.receive(10000);
+		assertNotNull(receive); //HelloWorld
+		assertEquals(0, receive.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE));
+		receive = this.fileSplittingResultChannel.receive(10000);
+		assertNotNull(receive); //äöüß
+		assertNull(this.fileSplittingResultChannel.receive(1));
+	}
+
 	@MessagingGateway(defaultRequestChannel = "controlBus.input")
 	private static interface ControlBusGateway {
 
@@ -258,6 +282,18 @@ public class FileTests {
 							.header("directory", new File(tmpDir.getRoot(), "fileWritingFlow")))
 					.handleWithAdapter(a -> a.fileGateway(m -> m.getHeaders().get("directory")))
 					.channel(MessageChannels.queue("fileWritingResultChannel"))
+					.get();
+		}
+
+
+		@Bean
+		public IntegrationFlow fileSplitterFlow() {
+			return IntegrationFlows
+					.from(s -> s.file(tmpDir.getRoot())
+									.patternFilter("foo.tmp"),
+							e -> e.poller(p -> p.fixedDelay(100)))
+					.split(Files.splitter().get())
+					.channel(c -> c.queue("fileSplittingResultChannel"))
 					.get();
 		}
 

--- a/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,7 +246,7 @@ public class FileTests {
 							e -> e.poller(Pollers.fixedDelay(100)))
 					.transform(Transformers.fileToString())
 					.aggregate(a -> a.correlationExpression("1")
-							.releaseStrategy(g -> g.size() == 25), null)
+							.releaseStrategy(g -> g.size() == 25))
 					.channel(MessageChannels.queue("fileReadingResultChannel"))
 					.get();
 		}

--- a/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
@@ -292,7 +292,7 @@ public class FileTests {
 					.from(s -> s.file(tmpDir.getRoot())
 									.patternFilter("foo.tmp"),
 							e -> e.poller(p -> p.fixedDelay(100)))
-					.split(Files.splitter().get())
+					.split(Files.splitter())
 					.channel(c -> c.queue("fileSplittingResultChannel"))
 					.get();
 		}

--- a/src/test/java/org/springframework/integration/dsl/test/flows/IntegrationFlowTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/flows/IntegrationFlowTests.java
@@ -75,6 +75,7 @@ import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.channel.DirectChannelSpec;
 import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.core.Pollers;
+import org.springframework.integration.dsl.support.GenericHandler;
 import org.springframework.integration.event.core.MessagingEvent;
 import org.springframework.integration.event.outbound.ApplicationEventPublishingMessageHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
@@ -1123,7 +1124,18 @@ public class IntegrationFlowTests {
 		@Bean
 		public IntegrationFlow flow3() {
 			return IntegrationFlows.from("flow3Input")
-					.handle(Integer.class, (p, h) -> p * 2)
+					.handle(Integer.class, new GenericHandler<Integer>() {
+
+						public void setFoo(String foo) {}
+
+						public void setFoo(Integer foo) {}
+
+						@Override
+						public Object handle(Integer p, Map<String, Object> h) {
+							return p * 2;
+						}
+
+					})
 					.handle(new ApplicationEventPublishingMessageHandler())
 					.get();
 		}
@@ -1341,7 +1353,7 @@ public class IntegrationFlowTests {
 					.<String, Integer>transform(Integer::parseInt)
 					.enrichHeaders(h ->
 							h.headerFunction(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, Message::getPayload))
-					.resequence(r -> r.releasePartialSequences(true).correlationExpression("'foo'"), null)
+					.resequence(r -> r.releasePartialSequences(true).correlationExpression("'foo'"))
 					.headerFilter("foo", false);
 		}
 

--- a/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
@@ -121,7 +121,7 @@ public class FlowServiceTests {
 			return from(this, "messageSource", e -> e.poller(p -> p.trigger(this::nextExecutionTime)))
 					.split(this)
 					.transform(this)
-					.aggregate(a -> a.processor(this, null), null)
+					.aggregate(a -> a.processor(this, null))
 					.enrichHeaders(Collections.singletonMap("foo", "FOO"))
 					.filter(this)
 					.handle(this)

--- a/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -67,25 +68,6 @@ import de.flapdoodle.embed.process.runtime.Network;
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
 public class MongoDbTests {
-
-	private static MongodExecutable mongodExe;
-
-	@BeforeClass
-	public static void setup() throws IOException {
-		int mongoPort = Network.getFreeServerPort();
-		mongodExe = MongodStarter.getDefaultInstance()
-				.prepare(new MongodConfigBuilder()
-						.version(Version.Main.PRODUCTION)
-						.net(new Net(mongoPort, Network.localhostIsIPv6()))
-						.build());
-		mongodExe.start();
-		System.setProperty("spring.data.mongodb.port", "" + mongoPort);
-	}
-
-	@AfterClass
-	public static void tearDown() {
-		mongodExe.stop();
-	}
 
 	@Autowired
 	private ControlBusGateway controlBus;
@@ -163,7 +145,8 @@ public class MongoDbTests {
 
 
 	@Configuration
-	@Import({MongoAutoConfiguration.class, MongoDataAutoConfiguration.class, IntegrationAutoConfiguration.class})
+	@Import({EmbeddedMongoAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
+			IntegrationAutoConfiguration.class})
 	@IntegrationComponentScan
 	public static class ContextConfiguration {
 


### PR DESCRIPTION
Fixes GH-22 (https://github.com/spring-projects/spring-integration-java-dsl/issues/22)
JIRA: https://jira.spring.io/browse/INTEXT-128, https://jira.spring.io/browse/INTEXT-188,
https://jira.spring.io/browse/INTEXT-184

* Add more options for `AggregatorSpec` and `ResequencerSpec`
* Rework design for `.aggregate()` and `.resequence()` to avoid extra `null` argument and explicit casting
* Add explicit method name for `.handle(GenericHandler)`, when the `GenericHandler` impl isn't `Lambda`
* Expose `RemoteFileTemplate` factory methods for the (S)Ftp factories
* Expose `MessageSessionCallback` factory methods for the (S)Ftp factories
* Rework `FileListFilter` logic and design for all affected components to make the target configuration
as more convenient