### PR TITLE
INTEXT-200: Fix default RemoteTemplate for (S)Ftp

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/Adapters.java
+++ b/src/main/java/org/springframework/integration/dsl/Adapters.java
@@ -116,7 +116,24 @@ public class Adapters {
 		return Ftp.outboundGateway(sessionFactory, command, expression);
 	}
 
+	/**
+	 * The factory method for the {@link Sftp#outboundAdapter}.
+	 * @param sessionFactory the {@link SessionFactory} to use.
+	 * @return an {@link SftpMessageHandlerSpec} instance.
+	 * @deprecated in favor of {@link #sftp(SessionFactory)}
+	 */
+	@Deprecated
 	public SftpMessageHandlerSpec ftps(SessionFactory<ChannelSftp.LsEntry> sessionFactory) {
+		return sftp(sessionFactory);
+	}
+
+	/**
+	 * The factory method for the {@link Sftp#outboundAdapter}.
+	 * @param sessionFactory the {@link SessionFactory} to use.
+	 * @return an {@link SftpMessageHandlerSpec} instance.
+	 * @since 1.1.1
+	 */
+	public SftpMessageHandlerSpec sftp(SessionFactory<ChannelSftp.LsEntry> sessionFactory) {
 		return Sftp.outboundAdapter(sessionFactory);
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/core/MessagingGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/core/MessagingGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,17 @@ public abstract class MessagingGatewaySpec<S extends MessagingGatewaySpec<S, G>,
 	}
 
 	/**
+	 * @param replyChannelName the name of replyChannel.
+	 * @return the spec.
+	 * @see MessagingGatewaySupport#setReplyChannelName(String)
+	 * @since 1.1.1
+	 */
+	public S replyChannel(String replyChannelName) {
+		this.target.setReplyChannelName(replyChannelName);
+		return _this();
+	}
+
+	/**
 	 * @param requestChannel the requestChannel.
 	 * @return the spec.
 	 * @see MessagingGatewaySupport#setRequestChannel(MessageChannel)
@@ -80,12 +91,34 @@ public abstract class MessagingGatewaySpec<S extends MessagingGatewaySpec<S, G>,
 	}
 
 	/**
+	 * @param requestChannelName the name of requestChannel.
+	 * @return the spec.
+	 * @see MessagingGatewaySupport#setRequestChannelName(String)
+	 * @since 1.1.1
+	 */
+	public S requestChannel(String requestChannelName) {
+		target.setRequestChannelName(requestChannelName);
+		return _this();
+	}
+
+	/**
 	 * @param errorChannel the errorChannel.
 	 * @return the spec.
 	 * @see MessagingGatewaySupport#setErrorChannel(MessageChannel)
 	 */
 	public S errorChannel(MessageChannel errorChannel) {
 		target.setErrorChannel(errorChannel);
+		return _this();
+	}
+
+	/**
+	 * @param errorChannelName the name of errorChannel.
+	 * @return the spec.
+	 * @see MessagingGatewaySupport#setErrorChannelName(String)
+	 * @since 1.1.1
+	 */
+	public S errorChannel(String errorChannelName) {
+		target.setErrorChannelName(errorChannelName);
 		return _this();
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/file/FileTransferringMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/file/FileTransferringMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.dsl.file;
 
-import java.lang.reflect.Constructor;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +33,6 @@ import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * @author Artem Bilan
@@ -55,27 +53,9 @@ public abstract class FileTransferringMessageHandlerSpec<F, S extends FileTransf
 		this.target = new FileTransferringMessageHandler<F>(remoteFileTemplate);
 	}
 
-	@SuppressWarnings("unchecked")
 	protected FileTransferringMessageHandlerSpec(RemoteFileTemplate<F> remoteFileTemplate,
-			FileExistsMode fileExistsMode) {
-		Constructor<?> fileExistsModeConstructor =
-				ClassUtils.getConstructorIfAvailable(FileTransferringMessageHandler.class, RemoteFileTemplate.class,
-						FileExistsMode.class);
-		if (fileExistsModeConstructor == null) {
-			logger.warn("The 'FileExistsMode' constructor argument for the 'FileTransferringMessageHandler' is " +
-					"available since Spring Integration 4.1. Will be ignored for previous versions.");
-			this.target = new FileTransferringMessageHandler<F>(remoteFileTemplate);
-		}
-		else {
-			try {
-				this.target =
-						(FileTransferringMessageHandler<F>) fileExistsModeConstructor.newInstance(remoteFileTemplate,
-								fileExistsMode);
-			}
-			catch (Exception e) {
-				throw new IllegalStateException(e);
-			}
-		}
+	                                             FileExistsMode fileExistsMode) {
+		this.target = new FileTransferringMessageHandler<F>(remoteFileTemplate, fileExistsMode);
 	}
 
 	public S autoCreateDirectory(boolean autoCreateDirectory) {

--- a/src/main/java/org/springframework/integration/dsl/ftp/Ftp.java
+++ b/src/main/java/org/springframework/integration/dsl/ftp/Ftp.java
@@ -27,6 +27,7 @@ import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOut
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.ftp.gateway.FtpOutboundGateway;
+import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
 
 /**
  * @author Artem Bilan
@@ -48,7 +49,7 @@ public abstract class Ftp {
 
 	public static FtpMessageHandlerSpec outboundAdapter(SessionFactory<FTPFile> sessionFactory,
 			FileExistsMode fileExistsMode) {
-		return outboundAdapter(new RemoteFileTemplate<FTPFile>(sessionFactory), fileExistsMode);
+		return outboundAdapter(new FtpRemoteFileTemplate(sessionFactory), fileExistsMode);
 	}
 
 	public static FtpMessageHandlerSpec outboundAdapter(RemoteFileTemplate<FTPFile> remoteFileTemplate) {

--- a/src/main/java/org/springframework/integration/dsl/http/HttpControllerEndpointSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/http/HttpControllerEndpointSpec.java
@@ -19,8 +19,12 @@ package org.springframework.integration.dsl.http;
 import org.springframework.integration.http.inbound.HttpRequestHandlingController;
 
 /**
+ * The {@link BaseHttpInboundEndpointSpec} implementation for the {@link HttpRequestHandlingController}.
+ *
  * @author Artem Bilan
+ *
  * @since 1.1
+ * @see HttpRequestHandlingController
  */
 public class HttpControllerEndpointSpec
 		extends BaseHttpInboundEndpointSpec<HttpControllerEndpointSpec, HttpRequestHandlingController> {

--- a/src/main/java/org/springframework/integration/dsl/http/HttpMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/http/HttpMessageHandlerSpec.java
@@ -44,8 +44,12 @@ import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
 /**
+ * The {@link MessageHandlerSpec} implementation for the {@link HttpRequestExecutingMessageHandler}.
+ *
  * @author Artem Bilan
+ *
  * @since 1.1
+ * @see HttpRequestExecutingMessageHandler
  */
 public class HttpMessageHandlerSpec
 		extends MessageHandlerSpec<HttpMessageHandlerSpec, HttpRequestExecutingMessageHandler>

--- a/src/main/java/org/springframework/integration/dsl/http/HttpRequestHandlerEndpointSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/http/HttpRequestHandlerEndpointSpec.java
@@ -19,8 +19,12 @@ package org.springframework.integration.dsl.http;
 import org.springframework.integration.http.inbound.HttpRequestHandlingMessagingGateway;
 
 /**
+ * The {@link BaseHttpInboundEndpointSpec} implementation for the {@link HttpRequestHandlingMessagingGateway}.
+ *
  * @author Artem Bilan
+ *
  * @since 1.1
+ * @see HttpRequestHandlingMessagingGateway
  */
 public class HttpRequestHandlerEndpointSpec
 		extends BaseHttpInboundEndpointSpec<HttpRequestHandlerEndpointSpec, HttpRequestHandlingMessagingGateway> {

--- a/src/main/java/org/springframework/integration/dsl/sftp/Sftp.java
+++ b/src/main/java/org/springframework/integration/dsl/sftp/Sftp.java
@@ -25,6 +25,7 @@ import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOut
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.sftp.gateway.SftpOutboundGateway;
+import org.springframework.integration.sftp.session.SftpRemoteFileTemplate;
 
 import com.jcraft.jsch.ChannelSftp;
 
@@ -48,7 +49,7 @@ public abstract class Sftp {
 
 	public static SftpMessageHandlerSpec outboundAdapter(SessionFactory<ChannelSftp.LsEntry> sessionFactory,
 			FileExistsMode fileExistsMode) {
-		return outboundAdapter(new RemoteFileTemplate<ChannelSftp.LsEntry>(sessionFactory), fileExistsMode);
+		return outboundAdapter(new SftpRemoteFileTemplate(sessionFactory), fileExistsMode);
 	}
 
 	public static SftpMessageHandlerSpec outboundAdapter(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate) {

--- a/src/test/java/org/springframework/integration/dsl/test/feed/FeedTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/feed/FeedTests.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.net.URL;
 import java.util.Properties;
@@ -38,7 +37,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
-import org.springframework.integration.dsl.MessageSources;
 import org.springframework.integration.metadata.MetadataStore;
 import org.springframework.integration.metadata.PropertiesPersistingMetadataStore;
 import org.springframework.messaging.Message;
@@ -111,10 +109,9 @@ public class FeedTests {
 		@Bean
 		public IntegrationFlow feedFlow() {
 			return IntegrationFlows
-					.from((MessageSources s) -> s
-							.feed(this.feedUrl, "feedTest")
-							.feedFetcher(new FileUrlFeedFetcher())
-							.metadataStore(metadataStore()),
+					.from(s -> s.feed(this.feedUrl, "feedTest")
+									.feedFetcher(new FileUrlFeedFetcher())
+									.metadataStore(metadataStore()),
 							e -> e.poller(p -> p.fixedDelay(100)))
 					.channel(c -> c.queue("entries"))
 					.get();

--- a/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/file/FileTests.java
@@ -25,12 +25,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
@@ -57,6 +57,7 @@ import org.springframework.integration.dsl.ftp.Ftp;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
+import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.ftp.session.DefaultFtpSessionFactory;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.support.MessageBuilder;
@@ -218,7 +219,8 @@ public class FtpTests {
 		@Bean
 		public IntegrationFlow ftpOutboundFlow() {
 			return IntegrationFlows.from("toFtpChannel")
-					.handle(Ftp.outboundAdapter(this.ftpSessionFactory)
+					// INTEXT-200
+					.handle(Ftp.outboundAdapter(this.ftpSessionFactory, FileExistsMode.FAIL)
 									.useTemporaryFileName(false)
 									.fileNameExpression("headers['" + FileHeaders.FILENAME + "']")
 									.remoteDirectory(this.ftpServer.getTargetFtpDirectory().getName())

--- a/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
-import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;

--- a/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
@@ -58,6 +58,7 @@ import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.remote.RemoteFileOperations;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
+import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.sftp.session.DefaultSftpSessionFactory;
 import org.springframework.integration.sftp.session.SftpRemoteFileTemplate;
@@ -240,7 +241,8 @@ public class SftpTests {
 		@Bean
 		public IntegrationFlow sftpOutboundFlow() {
 			return IntegrationFlows.from("toSftpChannel")
-					.handle(Sftp.outboundAdapter(this.sftpSessionFactory)
+					// INTEXT-200
+					.handle(Sftp.outboundAdapter(this.sftpSessionFactory, FileExistsMode.FAIL)
 									.useTemporaryFileName(false)
 									.remoteDirectory(this.sftpServer.getTargetSftpDirectory().getName())
 					).get();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-200

* The `RemoteFileTemplate` doesn't implement `exists()`, hence we
should use the target impl (`(S)FtpRemoteFileTemplate`) for the `FileTransferringMessageHandler` ctor with the `FileExistsMode`.
 * Remove SI-4.1 check from the `FileTransferringMessageHandlerSpec`
 * Add `*ChannelName` methods for the `MessagingGatewaySpec`
 * Add JavaDocs for the HTTP Specs
 * Deprecate the `ftps()` factory method by the typo reason in favor of `sftp()`
 * Remove unused `imports`
 * Fix compatibility with the latest Spring Boot B-S