### PR TITLE
INTEXT-209: AMQP: Fix container registration

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpInboundChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.dsl.amqp;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 
 import org.aopalliance.aop.Advice;
@@ -24,6 +26,7 @@ import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
+import org.springframework.integration.dsl.core.ComponentsRegistration;
 import org.springframework.integration.dsl.core.MessageProducerSpec;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.ErrorHandler;
@@ -33,7 +36,8 @@ import org.springframework.util.ErrorHandler;
  *
  * @author Artem Bilan
  */
-public class AmqpInboundChannelAdapterSpec extends AmqpBaseInboundChannelAdapterSpec<AmqpInboundChannelAdapterSpec> {
+public class AmqpInboundChannelAdapterSpec extends AmqpBaseInboundChannelAdapterSpec<AmqpInboundChannelAdapterSpec>
+		implements ComponentsRegistration {
 
 	private final SimpleMessageListenerContainer listenerContainer;
 
@@ -251,6 +255,11 @@ public class AmqpInboundChannelAdapterSpec extends AmqpBaseInboundChannelAdapter
 	public AmqpInboundChannelAdapterSpec defaultRequeueRejected(boolean defaultRequeueRejected) {
 		this.listenerContainer.setDefaultRequeueRejected(defaultRequeueRejected);
 		return this;
+	}
+
+	@Override
+	public Collection<Object> getComponentsToRegister() {
+		return Collections.<Object>singleton(this.listenerContainer);
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpInboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpInboundGatewaySpec.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.dsl.amqp;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 
 import org.aopalliance.aop.Advice;
@@ -25,6 +27,7 @@ import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.integration.amqp.inbound.AmqpInboundGateway;
+import org.springframework.integration.dsl.core.ComponentsRegistration;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.ErrorHandler;
 
@@ -34,7 +37,8 @@ import org.springframework.util.ErrorHandler;
  *
  * @author Artem Bilan
  */
-public class AmqpInboundGatewaySpec extends AmqpBaseInboundGatewaySpec<AmqpInboundGatewaySpec> {
+public class AmqpInboundGatewaySpec extends AmqpBaseInboundGatewaySpec<AmqpInboundGatewaySpec>
+		implements ComponentsRegistration {
 
 	private final SimpleMessageListenerContainer listenerContainer;
 
@@ -265,5 +269,11 @@ public class AmqpInboundGatewaySpec extends AmqpBaseInboundGatewaySpec<AmqpInbou
 		this.listenerContainer.setDefaultRequeueRejected(defaultRequeueRejected);
 		return this;
 	}
+
+	@Override
+	public Collection<Object> getComponentsToRegister() {
+		return Collections.<Object>singleton(this.listenerContainer);
+	}
+
 
 }

--- a/src/test/java/org/springframework/integration/dsl/test/amqp/AmqpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/amqp/AmqpTests.java
@@ -80,6 +80,10 @@ public class AmqpTests {
 		Object result = this.amqpTemplate.convertSendAndReceive(this.amqpQueue.getName(), "world");
 		assertEquals("HELLO WORLD", result);
 
+		this.amqpInboundGateway.stop();
+		//INTEXT-209
+		this.amqpInboundGateway.start();
+
 		this.amqpTemplate.convertAndSend(this.amqpQueue.getName(), "world");
 		((RabbitTemplate) this.amqpTemplate).setReceiveTimeout(10000);
 		result = this.amqpTemplate.receiveAndConvert("defaultReplyTo");


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-209

An internal `SimpleMessageListenerContainer` instance from the `Amqp.inboundGateway()/inboundAdapter()`
hasn't been registered as a bean in the application context. That causes issues when container interacts with the applicationContext.

Add `implements ComponentsRegistration` to the `AmqpInboundGatewaySpec` and `AmqpInboundChannelAdapterSpec`.
Add simple `stop()/start()` operation to the `AmqpTests` to be sure that the issue has gone.

**Cherry-pick to 1.0.x**