### PR TITLE
INTEXT-217: Cleanup KafkaProducerContext.beanName

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ ext {
 	reactorVersion = '2.0.7.RELEASE'
 	scalaVersion = '2.10'
 	slf4jVersion = '1.7.12'
-	springIntegrationVersion = '4.2.3.RELEASE'
+	springIntegrationVersion = '4.2.4.RELEASE'
 	springIntegrationKafkaVersion = '1.2.1.RELEASE'
 	springBootVersion = '1.3.0.RELEASE'
 	testNgVersion = '6.8.21'

--- a/src/main/java/org/springframework/integration/dsl/kafka/KafkaProducerMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/kafka/KafkaProducerMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors
+ * Copyright 2015-2016 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ public class KafkaProducerMessageHandlerSpec
 	KafkaProducerMessageHandlerSpec(Properties producerProperties) {
 		this.producerProperties = producerProperties;
 		this.kafkaProducerContext = new KafkaProducerContext();
+		this.kafkaProducerContext.setBeanName(null);
 		this.target = new KafkaProducerMessageHandler(kafkaProducerContext);
 	}
 

--- a/src/test/java/org/springframework/integration/dsl/test/kafka/KafkaTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/kafka/KafkaTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors
+ * Copyright 2015-2016 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.I0Itec.zkclient.ZkClient;
@@ -58,6 +59,7 @@ import org.springframework.integration.kafka.listener.Acknowledgment;
 import org.springframework.integration.kafka.listener.MetadataStoreOffsetManager;
 import org.springframework.integration.kafka.outbound.KafkaProducerMessageHandler;
 import org.springframework.integration.kafka.support.KafkaHeaders;
+import org.springframework.integration.kafka.support.KafkaProducerContext;
 import org.springframework.integration.kafka.support.ProducerMetadata;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
 import org.springframework.integration.kafka.util.EncoderAdaptingSerializer;
@@ -100,6 +102,8 @@ public class KafkaTests {
 
 	private static final String TEST_TOPIC2 = "test-topic2";
 
+	private static final String TEST_TOPIC3 = "test-topic3";
+
 	@Autowired
 	@Qualifier("sendToKafkaFlow.input")
 	private MessageChannel sendToKafkaFlowInput;
@@ -115,6 +119,10 @@ public class KafkaTests {
 	@Qualifier("kafkaProducer.handler")
 	private KafkaProducerMessageHandler kafkaProducer;
 
+	@Autowired
+	@Qualifier("kafkaProducer3.handler")
+	private KafkaProducerMessageHandler kafkaProducer3;
+
 
 	@Test
 	@SuppressWarnings("unchecked")
@@ -127,7 +135,8 @@ public class KafkaTests {
 			assertThat(e.getMessage(), containsString("is not in the range [0...1]"));
 		}
 
-		kafkaProducer.setPartitionExpression(new ValueExpression<>(0));
+		this.kafkaProducer.setPartitionExpression(new ValueExpression<>(0));
+		this.kafkaProducer3.setPartitionExpression(new ValueExpression<>(0));
 		this.sendToKafkaFlowInput.send(new GenericMessage<>("foo"));
 
 		for (int i = 0; i < 100; i++) {
@@ -190,7 +199,7 @@ public class KafkaTests {
 		                                     List<KafkaServer> kafkaServers) {
 			return new InitializingBean() {
 
-				private final List<String> topics = Arrays.asList(TEST_TOPIC, TEST_TOPIC2);
+				private final List<String> topics = Arrays.asList(TEST_TOPIC, TEST_TOPIC2, TEST_TOPIC3);
 
 				@Override
 				public void afterPropertiesSet() throws Exception {
@@ -240,11 +249,16 @@ public class KafkaTests {
 		@Bean
 		public IntegrationFlow sendToKafkaFlow(String serverAddress) {
 			return f -> f.<String>split(p -> FastList.newWithNValues(100, () -> p), null)
-					.handle(kafkaMessageHandler(serverAddress), e -> e.id("kafkaProducer"));
+					.publishSubscribeChannel(c -> c
+							.subscribe(sf -> sf.handle(kafkaMessageHandler(serverAddress, TEST_TOPIC),
+									e -> e.id("kafkaProducer")))
+							.subscribe(sf -> sf.handle(kafkaMessageHandler(serverAddress, TEST_TOPIC3),
+									e -> e.id("kafkaProducer3")))
+							);
 		}
 
 		@SuppressWarnings("unchecked")
-		private KafkaProducerMessageHandlerSpec kafkaMessageHandler(String serverAddress) {
+		private KafkaProducerMessageHandlerSpec kafkaMessageHandler(String serverAddress, String topic) {
 			Encoder<?> intEncoder = new IntEncoder(null);
 			return Kafka
 					.outboundChannelAdapter(props -> props
@@ -254,7 +268,7 @@ public class KafkaTests {
 							.get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER))
 					.partitionId(m -> 1)
 					.addProducer(
-							new ProducerMetadata<>(TEST_TOPIC, Integer.class, String.class,
+							new ProducerMetadata<>(topic, Integer.class, String.class,
 									new EncoderAdaptingSerializer<>((Encoder<Integer>) intEncoder),
 									new StringSerializer()),
 							serverAddress);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-217

The `KafkaProducerMessageHandlerSpec` provides an internal `KafkaProducerContext` for the bean registration.
The `KafkaProducerContext` is `NamedComponent` and we don't generate `beanName` for it because its value is `not_specified` by default.
That causes the `duplicate bean` issue in case of several ` Kafka.outboundChannelAdapter()`

* Clean the `KafkaProducerContext.beanName` in the `KafkaProducerMessageHandlerSpec` to allow `IntegrationFlowBeanPostProcessor` to generate
an unique `beanName` for each `KafkaProducerContext` bean definition.