### PR TITLE
GH-59, GH-57 Fix ApplicationListener registration

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/kafka/KafkaProducerMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/kafka/KafkaProducerMessageHandlerSpec.java
@@ -238,6 +238,20 @@ public class KafkaProducerMessageHandlerSpec
 		return _this();
 	}
 
+	/**
+	 * Add Kafka Producer to this {@link KafkaProducerMessageHandler}
+	 * for the provided {@link ProducerConfiguration}.
+	 * @param producerConfiguration the {@link ProducerConfiguration} - options for Kafka {@link Producer}.
+	 * @return the spec.
+	 * @since 1.1.3
+	 */
+	public KafkaProducerMessageHandlerSpec addProducer(ProducerConfiguration producerConfiguration) {
+		Assert.notNull(producerConfiguration);
+		this.producerConfigurations.put(producerConfiguration.getProducerMetadata().getTopic(),
+					producerConfiguration);
+		return _this();
+	}
+
 	@Override
 	public Collection<Object> getComponentsToRegister() {
 		this.kafkaProducerContext.setProducerConfigurations(this.producerConfigurations);


### PR DESCRIPTION
Fixes GH-59 (https://github.com/spring-projects/spring-integration-java-dsl/issues/59)
Fixes GH-57 (https://github.com/spring-projects/spring-integration-java-dsl/issues/57)

* Components from DSL are registered as beans in the `ApplicationContext`
from the `IntegrationFlowBeanPostProcessor`,
but `AbstractApplicationContext.registerListeners()` is definitely called before any `BPP`.
So, implement `SmartInitializingSingleton` logic for the `IntegrationFlowBeanPostProcessor` to register
`ApplicationListener` in the `ApplicationEventMulticaster` directly.
By the way the same is done from the `EventListenerMethodProcessor`.

* Since we can't upgrade to the Spring Integration Kafka 1.3 in the current point release,
Introduce the `KafkaProducerMessageHandlerSpec.addProducer(ProducerConfiguration producerConfiguration)`
to have ability to accept the `ProducerConfiguration` with provided `ProducerListener`.