### PR TITLE
Auto-configure JMX so that MBeanServer bean is available

### DIFF
--- a/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
@@ -38,10 +38,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -182,7 +182,7 @@ public class FtpTests {
 	}
 
 	@Configuration
-	@Import({TestFtpServer.class, IntegrationAutoConfiguration.class})
+	@Import({TestFtpServer.class, JmxAutoConfiguration.class, IntegrationAutoConfiguration.class})
 	@IntegrationComponentScan
 	public static class ContextConfiguration {
 

--- a/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.annotation.PostConstruct;
 import javax.jms.ConnectionFactory;
 
@@ -30,12 +31,12 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -198,7 +199,7 @@ public class JmsTests {
 	}
 
 	@Configuration
-	@Import({ActiveMQAutoConfiguration.class, IntegrationAutoConfiguration.class})
+	@Import({ActiveMQAutoConfiguration.class, JmxAutoConfiguration.class, IntegrationAutoConfiguration.class})
 	@IntegrationComponentScan
 	@ComponentScan
 	public static class ContextConfiguration {

--- a/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
@@ -38,10 +38,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -204,7 +204,7 @@ public class SftpTests {
 	}
 
 	@Configuration
-	@Import({TestSftpServer.class, IntegrationAutoConfiguration.class})
+	@Import({TestSftpServer.class, JmxAutoConfiguration.class, IntegrationAutoConfiguration.class})
 	@IntegrationComponentScan
 	public static class ContextConfiguration {
 


### PR DESCRIPTION
This PR paves the way for building against Spring Boot 1.3.4 (which has not yet been released). The problem was found by the IO Platform 2.0.x compatibility tests. The changes should be benign when building against early versions of Boot. Please see the commit message for further details.