### PR TITLE
Polishing after upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,3 @@
-description = 'Spring Integration Java DSL'
-
-apply plugin: 'java'
-apply from: "${rootProject.projectDir}/publish-maven.gradle"
-apply plugin: 'eclipse'
-apply plugin: 'idea'
-apply plugin: 'jacoco'
-
 buildscript {
 	repositories {
 		maven { url 'http://repo.spring.io/plugins-release' }
@@ -14,6 +6,18 @@ buildscript {
 		classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
 	}
 }
+
+plugins {
+	id "org.sonarqube" version "1.2"
+}
+
+description = 'Spring Integration Java DSL'
+
+apply plugin: 'java'
+apply from: "${rootProject.projectDir}/publish-maven.gradle"
+apply plugin: 'eclipse'
+apply plugin: 'idea'
+apply plugin: 'jacoco'
 
 group = 'org.springframework.integration'
 
@@ -206,10 +210,8 @@ artifacts {
 	archives javadocJar
 }
 
-apply plugin: 'sonar-runner'
-
-sonarRunner {
-	sonarProperties {
+sonarqube {
+	properties {
 		property "sonar.jacoco.reportPath", "${buildDir.name}/jacoco.exec"
 		property "sonar.links.homepage", linkHomepage
 		property "sonar.links.ci", linkCi

--- a/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,8 +171,12 @@ public abstract class
 	 */
 	public S processor(Object target) {
 		try {
-			return correlationStrategy(new CorrelationStrategyFactoryBean(target).getObject())
-					.releaseStrategy(new ReleaseStrategyFactoryBean(target).getObject());
+			CorrelationStrategyFactoryBean correlationStrategyFactoryBean = new CorrelationStrategyFactoryBean();
+			correlationStrategyFactoryBean.setTarget(target);
+			ReleaseStrategyFactoryBean releaseStrategyFactoryBean = new ReleaseStrategyFactoryBean();
+			releaseStrategyFactoryBean.setTarget(target);
+			return correlationStrategy(correlationStrategyFactoryBean.getObject())
+					.releaseStrategy(releaseStrategyFactoryBean.getObject());
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);
@@ -201,7 +205,10 @@ public abstract class
 	 */
 	public S correlationStrategy(Object target, String methodName) {
 		try {
-			return correlationStrategy(new CorrelationStrategyFactoryBean(target, methodName).getObject());
+			CorrelationStrategyFactoryBean correlationStrategyFactoryBean = new CorrelationStrategyFactoryBean();
+			correlationStrategyFactoryBean.setTarget(target);
+			correlationStrategyFactoryBean.setMethodName(methodName);
+			return correlationStrategy(correlationStrategyFactoryBean.getObject());
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);
@@ -240,7 +247,10 @@ public abstract class
 	 */
 	public S releaseStrategy(Object target, String methodName) {
 		try {
-			return releaseStrategy(new ReleaseStrategyFactoryBean(target, methodName).getObject());
+			ReleaseStrategyFactoryBean releaseStrategyFactoryBean = new ReleaseStrategyFactoryBean();
+			releaseStrategyFactoryBean.setTarget(target);
+			releaseStrategyFactoryBean.setMethodName(methodName);
+			return releaseStrategy(releaseStrategyFactoryBean.getObject());
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpBaseInboundChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpBaseInboundChannelAdapterSpec.java
@@ -30,7 +30,7 @@ import org.springframework.integration.dsl.core.MessageProducerSpec;
 public class AmqpBaseInboundChannelAdapterSpec<S extends AmqpBaseInboundChannelAdapterSpec<S>>
 		extends MessageProducerSpec<S, AmqpInboundChannelAdapter> {
 
-	private final DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+	private final DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.inboundMapper();
 
 	AmqpBaseInboundChannelAdapterSpec(AmqpInboundChannelAdapter producer) {
 		super(producer);

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpBaseInboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpBaseInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.integration.dsl.core.MessagingGatewaySpec;
 public class AmqpBaseInboundGatewaySpec<S extends AmqpBaseInboundGatewaySpec<S>>
 		extends MessagingGatewaySpec<S, AmqpInboundGateway> {
 
-	private final DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+	private final DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.inboundMapper();
 
 	AmqpBaseInboundGatewaySpec(AmqpInboundGateway gateway) {
 		super(gateway);

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class AmqpOutboundEndpointSpec extends MessageHandlerSpec<AmqpOutboundEnd
 
 	private final boolean expectReply;
 
-	private final DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+	private final DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.outboundMapper();
 
 	AmqpOutboundEndpointSpec(AmqpTemplate amqpTemplate, boolean expectReply) {
 		this.endpoint = new AmqpOutboundEndpoint(amqpTemplate);

--- a/src/main/java/org/springframework/integration/dsl/kafka/Kafka.java
+++ b/src/main/java/org/springframework/integration/dsl/kafka/Kafka.java
@@ -82,6 +82,7 @@ public abstract class Kafka {
 	 * @param messageListenerContainer the {@link KafkaMessageListenerContainer}.
 	 * @return the KafkaMessageDrivenChannelAdapterSpec.
 	 */
+	@SuppressWarnings("rawtypes")
 	public static KafkaMessageDrivenChannelAdapterSpec messageDriverChannelAdapter(
 			KafkaMessageListenerContainer messageListenerContainer) {
 		return new KafkaMessageDrivenChannelAdapterSpec(messageListenerContainer);

--- a/src/main/java/org/springframework/integration/dsl/kafka/Kafka09.java
+++ b/src/main/java/org/springframework/integration/dsl/kafka/Kafka09.java
@@ -36,6 +36,8 @@ public abstract class Kafka09 {
 	/**
 	 * Create an initial {@link Kafka09ProducerMessageHandlerSpec}.
 	 * @param kafkaTemplate the {@link KafkaTemplate} to use
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
 	 * @return the Kafka09ProducerMessageHandlerSpec.
 	 */
 	public static <K, V> Kafka09ProducerMessageHandlerSpec<K, V>
@@ -46,10 +48,12 @@ public abstract class Kafka09 {
 	/**
 	 * Create an initial {@link Kafka09ProducerMessageHandlerSpec} with ProducerFactory.
 	 * @param producerFactory the {@link ProducerFactory} Java 8 Lambda.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
 	 * @return the KafkaProducerMessageHandlerSpec.
 	 * @see <a href="https://kafka.apache.org/documentation.html#producerconfigs">Kafka Producer Configs</a>
 	 */
-	public static <K, V> Kafka09ProducerMessageHandlerSpec.KafkaProducerMessageHandlerTemplateSpec
+	public static <K, V> Kafka09ProducerMessageHandlerSpec.KafkaProducerMessageHandlerTemplateSpec<K, V>
 	outboundChannelAdapter(ProducerFactory<K, V> producerFactory) {
 		return new Kafka09ProducerMessageHandlerSpec.KafkaProducerMessageHandlerTemplateSpec<K, V>(producerFactory);
 	}
@@ -57,11 +61,15 @@ public abstract class Kafka09 {
 	/**
 	 * Create an initial {@link Kafka09MessageDrivenChannelAdapterSpec}.
 	 * @param listenerContainer the {@link AbstractMessageListenerContainer}.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @param <A> the {@link Kafka09MessageDrivenChannelAdapterSpec} extension type.
 	 * @return the Kafka09MessageDrivenChannelAdapterSpec.
 	 */
-	public static Kafka09MessageDrivenChannelAdapterSpec messageDriverChannelAdapter(
-			AbstractMessageListenerContainer<?, ?> listenerContainer) {
-		return new Kafka09MessageDrivenChannelAdapterSpec(listenerContainer);
+	public static <K, V, A extends Kafka09MessageDrivenChannelAdapterSpec<K, V, A>>
+	Kafka09MessageDrivenChannelAdapterSpec<K, V, A> messageDriverChannelAdapter(
+			AbstractMessageListenerContainer<K, V> listenerContainer) {
+		return new Kafka09MessageDrivenChannelAdapterSpec<K, V, A>(listenerContainer);
 	}
 
 	/**
@@ -69,12 +77,15 @@ public abstract class Kafka09 {
 	 * {@link Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec}.
 	 * @param consumerFactory the {@link ConsumerFactory}.
 	 * @param topicPartitions the {@link TopicPartition} vararg.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
 	 * @return the KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec.
 	 */
-	public static Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec
-	messageDriverChannelAdapter(ConsumerFactory<?, ?> consumerFactory, TopicPartition... topicPartitions) {
+	public static <K, V>
+	Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V>
+	messageDriverChannelAdapter(ConsumerFactory<K, V> consumerFactory, TopicPartition... topicPartitions) {
 		return messageDriverChannelAdapter(
-				new Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec(consumerFactory,
+				new Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec<K, V>(consumerFactory,
 						topicPartitions));
 	}
 
@@ -83,12 +94,15 @@ public abstract class Kafka09 {
 	 * {@link Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec}.
 	 * @param consumerFactory the {@link ConsumerFactory}.
 	 * @param topics the topics vararg.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
 	 * @return the KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec.
 	 */
-	public static Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec
-	messageDriverChannelAdapter(ConsumerFactory<?, ?> consumerFactory, String... topics) {
+	public static <K, V>
+	Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V>
+	messageDriverChannelAdapter(ConsumerFactory<K, V> consumerFactory, String... topics) {
 		return messageDriverChannelAdapter(
-				new Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec(consumerFactory,
+				new Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec<K, V>(consumerFactory,
 						topics));
 	}
 
@@ -97,18 +111,23 @@ public abstract class Kafka09 {
 	 * {@link Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec}.
 	 * @param consumerFactory the {@link ConsumerFactory}.
 	 * @param topicPattern the topicPattern vararg.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
 	 * @return the KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec.
 	 */
-	public static Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec
-	messageDriverChannelAdapter(ConsumerFactory<?, ?> consumerFactory, Pattern topicPattern) {
+	public static <K, V>
+	Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V>
+	messageDriverChannelAdapter(ConsumerFactory<K, V> consumerFactory, Pattern topicPattern) {
 		return messageDriverChannelAdapter(
-				new Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec(consumerFactory,
+				new Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec<K, V>(consumerFactory,
 						topicPattern));
 	}
 
-	private static Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec
-	messageDriverChannelAdapter(Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec spec) {
-		return new Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec(spec);
+	private static <K, V>
+	Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V>
+	messageDriverChannelAdapter(Kafka09MessageDrivenChannelAdapterSpec.KafkaMessageListenerContainerSpec<K, V> spec) {
+		return new Kafka09MessageDrivenChannelAdapterSpec
+				.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V>(spec);
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/kafka/Kafka09MessageDrivenChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/kafka/Kafka09MessageDrivenChannelAdapterSpec.java
@@ -39,10 +39,10 @@ import org.springframework.util.Assert;
  *
  * @since 1.2
  */
-public class Kafka09MessageDrivenChannelAdapterSpec<S extends Kafka09MessageDrivenChannelAdapterSpec<S>>
-		extends MessageProducerSpec<S, Kafka09MessageDrivenChannelAdapter> {
+public class Kafka09MessageDrivenChannelAdapterSpec<K, V, S extends Kafka09MessageDrivenChannelAdapterSpec<K, V, S>>
+		extends MessageProducerSpec<S, Kafka09MessageDrivenChannelAdapter<K, V>> {
 
-	<K, V> Kafka09MessageDrivenChannelAdapterSpec(AbstractMessageListenerContainer<K, V> messageListenerContainer) {
+	Kafka09MessageDrivenChannelAdapterSpec(AbstractMessageListenerContainer<K, V> messageListenerContainer) {
 		super(new Kafka09MessageDrivenChannelAdapter<K, V>(messageListenerContainer));
 	}
 
@@ -81,13 +81,13 @@ public class Kafka09MessageDrivenChannelAdapterSpec<S extends Kafka09MessageDriv
 	 * A {@link ConcurrentMessageListenerContainer} configuration {@link Kafka09MessageDrivenChannelAdapterSpec}
 	 * extension.
 	 */
-	public static class KafkaMessageDrivenChannelAdapterListenerContainerSpec extends
-			Kafka09MessageDrivenChannelAdapterSpec<KafkaMessageDrivenChannelAdapterListenerContainerSpec>
+	public static class KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V> extends
+			Kafka09MessageDrivenChannelAdapterSpec<K, V, KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V>>
 			implements ComponentsRegistration {
 
-		private KafkaMessageListenerContainerSpec spec;
+		private KafkaMessageListenerContainerSpec<K, V> spec;
 
-		KafkaMessageDrivenChannelAdapterListenerContainerSpec(KafkaMessageListenerContainerSpec spec) {
+		KafkaMessageDrivenChannelAdapterListenerContainerSpec(KafkaMessageListenerContainerSpec<K, V> spec) {
 			super(spec.container);
 			this.spec = spec;
 		}
@@ -98,8 +98,8 @@ public class Kafka09MessageDrivenChannelAdapterSpec<S extends Kafka09MessageDriv
 		 * @param configurer the configurer Java 8 Lambda.
 		 * @return the spec.
 		 */
-		public KafkaMessageDrivenChannelAdapterListenerContainerSpec configureListenerContainer(
-				Consumer<KafkaMessageListenerContainerSpec> configurer) {
+		public KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V> configureListenerContainer(
+				Consumer<KafkaMessageListenerContainerSpec<K, V>> configurer) {
 			Assert.notNull(configurer);
 			configurer.accept(this.spec);
 			return _this();
@@ -116,20 +116,20 @@ public class Kafka09MessageDrivenChannelAdapterSpec<S extends Kafka09MessageDriv
 	 * A helper class in the Builder pattern style to delegate options to the
 	 * {@link ConcurrentMessageListenerContainer}.
 	 */
-	public static class KafkaMessageListenerContainerSpec {
+	public static class KafkaMessageListenerContainerSpec<K, V> {
 
-		private final ConcurrentMessageListenerContainer<?, ?> container;
+		private final ConcurrentMessageListenerContainer<K, V> container;
 
-		<K, V> KafkaMessageListenerContainerSpec(ConsumerFactory<K, V> consumerFactory,
+		KafkaMessageListenerContainerSpec(ConsumerFactory<K, V> consumerFactory,
 				TopicPartition... topicPartitions) {
 			this.container = new ConcurrentMessageListenerContainer<K, V>(consumerFactory, topicPartitions);
 		}
 
-		<K, V> KafkaMessageListenerContainerSpec(ConsumerFactory<K, V> consumerFactory, String... topics) {
+		KafkaMessageListenerContainerSpec(ConsumerFactory<K, V> consumerFactory, String... topics) {
 			this.container = new ConcurrentMessageListenerContainer<K, V>(consumerFactory, topics);
 		}
 
-		<K, V> KafkaMessageListenerContainerSpec(ConsumerFactory<K, V> consumerFactory, Pattern topicPattern) {
+		KafkaMessageListenerContainerSpec(ConsumerFactory<K, V> consumerFactory, Pattern topicPattern) {
 			this.container = new ConcurrentMessageListenerContainer<K, V>(consumerFactory, topicPattern);
 		}
 
@@ -139,7 +139,7 @@ public class Kafka09MessageDrivenChannelAdapterSpec<S extends Kafka09MessageDriv
 		 * @return the spec.
 		 * @see ErrorHandler
 		 */
-		public KafkaMessageListenerContainerSpec errorHandler(ErrorHandler errorHandler) {
+		public KafkaMessageListenerContainerSpec<K, V> errorHandler(ErrorHandler errorHandler) {
 			this.container.setErrorHandler(errorHandler);
 			return this;
 		}
@@ -150,37 +150,37 @@ public class Kafka09MessageDrivenChannelAdapterSpec<S extends Kafka09MessageDriv
 		 * @return the spec.
 		 * @see ConcurrentMessageListenerContainer#setConcurrency(int)
 		 */
-		public KafkaMessageListenerContainerSpec concurrency(int concurrency) {
+		public KafkaMessageListenerContainerSpec<K, V> concurrency(int concurrency) {
 			this.container.setConcurrency(concurrency);
 			return this;
 		}
 
-		public KafkaMessageListenerContainerSpec ackMode(AbstractMessageListenerContainer.AckMode ackMode) {
+		public KafkaMessageListenerContainerSpec<K, V> ackMode(AbstractMessageListenerContainer.AckMode ackMode) {
 			this.container.setAckMode(ackMode);
 			return this;
 		}
 
-		public KafkaMessageListenerContainerSpec pollTimeout(long pollTimeout) {
+		public KafkaMessageListenerContainerSpec<K, V> pollTimeout(long pollTimeout) {
 			this.container.setPollTimeout(pollTimeout);
 			return this;
 		}
 
-		public KafkaMessageListenerContainerSpec ackCount(int count) {
+		public KafkaMessageListenerContainerSpec<K, V> ackCount(int count) {
 			this.container.setAckCount(count);
 			return this;
 		}
 
-		public KafkaMessageListenerContainerSpec ackTime(long millis) {
+		public KafkaMessageListenerContainerSpec<K, V> ackTime(long millis) {
 			this.container.setAckTime(millis);
 			return this;
 		}
 
-		public KafkaMessageListenerContainerSpec taskExecutor(Executor taskExecutor) {
+		public KafkaMessageListenerContainerSpec<K, V> taskExecutor(Executor taskExecutor) {
 			this.container.setTaskExecutor(taskExecutor);
 			return this;
 		}
 
-		public KafkaMessageListenerContainerSpec recentOffset(long recentOffset) {
+		public KafkaMessageListenerContainerSpec<K, V> recentOffset(long recentOffset) {
 			this.container.setRecentOffset(recentOffset);
 			return this;
 		}

--- a/src/main/java/org/springframework/integration/dsl/kafka/Kafka09ProducerMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/kafka/Kafka09ProducerMessageHandlerSpec.java
@@ -53,7 +53,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param topic the Kafka topic name.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec topic(String topic) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> topic(String topic) {
 		return topicExpression(new LiteralExpression(topic));
 	}
 
@@ -64,7 +64,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param topicExpression the topic SpEL expression.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec topicExpression(String topicExpression) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> topicExpression(String topicExpression) {
 		return topicExpression(PARSER.parseExpression(topicExpression));
 	}
 
@@ -74,7 +74,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param topicExpression the topic expression.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec topicExpression(Expression topicExpression) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> topicExpression(Expression topicExpression) {
 		this.target.setTopicExpression(topicExpression);
 		return _this();
 	}
@@ -92,7 +92,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @return the current {@link Kafka09ProducerMessageHandlerSpec}.
 	 * @see FunctionExpression
 	 */
-	public <P> Kafka09ProducerMessageHandlerSpec topic(Function<Message<P>, String> topicFunction) {
+	public <P> Kafka09ProducerMessageHandlerSpec<K, V> topic(Function<Message<P>, String> topicFunction) {
 		return topicExpression(new FunctionExpression<Message<P>>(topicFunction));
 	}
 
@@ -102,7 +102,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param messageKeyExpression the message key SpEL expression.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec messageKeyExpression(String messageKeyExpression) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> messageKeyExpression(String messageKeyExpression) {
 		return messageKeyExpression(PARSER.parseExpression(messageKeyExpression));
 	}
 
@@ -111,7 +111,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param messageKey the message key to use.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec messageKey(String messageKey) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> messageKey(String messageKey) {
 		return messageKeyExpression(new LiteralExpression(messageKey));
 	}
 
@@ -121,7 +121,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param messageKeyExpression the message key expression.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec messageKeyExpression(Expression messageKeyExpression) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> messageKeyExpression(Expression messageKeyExpression) {
 		target.setMessageKeyExpression(messageKeyExpression);
 		return _this();
 	}
@@ -139,7 +139,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @return the current {@link Kafka09ProducerMessageHandlerSpec}.
 	 * @see FunctionExpression
 	 */
-	public <P> Kafka09ProducerMessageHandlerSpec messageKey(Function<Message<P>, ?> messageKeyFunction) {
+	public <P> Kafka09ProducerMessageHandlerSpec<K, V> messageKey(Function<Message<P>, ?> messageKeyFunction) {
 		return messageKeyExpression(new FunctionExpression<Message<P>>(messageKeyFunction));
 	}
 
@@ -148,7 +148,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param partitionId the partitionId to use.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec partitionId(Integer partitionId) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> partitionId(Integer partitionId) {
 		return partitionIdExpression(new ValueExpression<Integer>(partitionId));
 	}
 
@@ -158,7 +158,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param partitionIdExpression the partitionId expression to use.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec partitionIdExpression(String partitionIdExpression) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> partitionIdExpression(String partitionIdExpression) {
 		return partitionIdExpression(PARSER.parseExpression(partitionIdExpression));
 	}
 
@@ -174,7 +174,7 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param <P> the expected payload type.
 	 * @return the spec.
 	 */
-	public <P> Kafka09ProducerMessageHandlerSpec partitionId(Function<Message<P>, Integer> partitionIdFunction) {
+	public <P> Kafka09ProducerMessageHandlerSpec<K, V> partitionId(Function<Message<P>, Integer> partitionIdFunction) {
 		return partitionIdExpression(new FunctionExpression<Message<P>>(partitionIdFunction));
 	}
 
@@ -184,13 +184,13 @@ public class Kafka09ProducerMessageHandlerSpec<K, V>
 	 * @param partitionIdExpression the partitionId expression to use.
 	 * @return the spec.
 	 */
-	public Kafka09ProducerMessageHandlerSpec partitionIdExpression(Expression partitionIdExpression) {
+	public Kafka09ProducerMessageHandlerSpec<K, V> partitionIdExpression(Expression partitionIdExpression) {
 		this.target.setPartitionIdExpression(partitionIdExpression);
 		return _this();
 	}
 
 	@Override
-	protected Kafka09ProducerMessageHandler doGet() {
+	protected Kafka09ProducerMessageHandler<K, V> doGet() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/kafka/KafkaHighLevelConsumerMessageSourceSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/kafka/KafkaHighLevelConsumerMessageSourceSpec.java
@@ -28,35 +28,31 @@ import org.springframework.integration.dsl.core.MessageSourceSpec;
 import org.springframework.integration.dsl.support.Consumer;
 import org.springframework.integration.dsl.support.MapBuilder;
 import org.springframework.integration.dsl.support.PropertiesBuilder;
-import org.springframework.integration.kafka.inbound.KafkaHighLevelConsumerMessageSource;
-import org.springframework.integration.kafka.support.ConsumerConfigFactoryBean;
-import org.springframework.integration.kafka.support.ConsumerConfiguration;
-import org.springframework.integration.kafka.support.ConsumerConnectionProvider;
-import org.springframework.integration.kafka.support.ConsumerMetadata;
-import org.springframework.integration.kafka.support.KafkaConsumerContext;
-import org.springframework.integration.kafka.support.MessageLeftOverTracker;
-import org.springframework.integration.kafka.support.TopicFilterConfiguration;
-import org.springframework.integration.kafka.support.ZookeeperConnect;
+//TODO This asterisk import to avoid 'deprecated' compiler warning. This class will be removed in the next major release.
+import org.springframework.integration.kafka.support.*;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
 import kafka.serializer.Decoder;
 
 /**
- * A {@link MessageSourceSpec} for {@link KafkaHighLevelConsumerMessageSource}.
+ * A {@link MessageSourceSpec}
+ * for {@link org.springframework.integration.kafka.inbound.KafkaHighLevelConsumerMessageSource}.
  *
  * @author Artem Bilan
  * @since 1.1
  */
 @SuppressWarnings({"rawtypes", "unchecked", "deprecation"})
 public class KafkaHighLevelConsumerMessageSourceSpec
-		extends MessageSourceSpec<KafkaHighLevelConsumerMessageSourceSpec, KafkaHighLevelConsumerMessageSource<?, ?>>
+		extends MessageSourceSpec<KafkaHighLevelConsumerMessageSourceSpec,
+		org.springframework.integration.kafka.inbound.KafkaHighLevelConsumerMessageSource<?, ?>>
 		implements ComponentsRegistration {
 
 	private final KafkaConsumerContext consumerContext = new KafkaConsumerContext();
 
-	private final KafkaHighLevelConsumerMessageSource kafkaHighLevelConsumerMessageSource =
-			new KafkaHighLevelConsumerMessageSource(this.consumerContext);
+	private final org.springframework.integration.kafka.inbound.KafkaHighLevelConsumerMessageSource
+			kafkaHighLevelConsumerMessageSource =
+			new org.springframework.integration.kafka.inbound.KafkaHighLevelConsumerMessageSource(this.consumerContext);
 
 	private final Map<String, ConsumerConfiguration> consumerConfigurations =
 			new HashMap<String, ConsumerConfiguration>();
@@ -91,7 +87,8 @@ public class KafkaHighLevelConsumerMessageSourceSpec
 	}
 
 	/**
-	 * Add Kafka High Level Consumer to this {@link KafkaHighLevelConsumerMessageSource}
+	 * Add Kafka High Level Consumer to this
+	 * {@link org.springframework.integration.kafka.inbound.KafkaHighLevelConsumerMessageSource}
 	 * under provided {@code groupId}.
 	 * @param groupId the Consumer group id.
 	 * @param consumerMetadataSpec the Consumer metadata Java 8 Lambda.
@@ -119,7 +116,7 @@ public class KafkaHighLevelConsumerMessageSourceSpec
 	}
 
 	@Override
-	protected KafkaHighLevelConsumerMessageSource<?, ?> doGet() {
+	protected org.springframework.integration.kafka.inbound.KafkaHighLevelConsumerMessageSource<?, ?> doGet() {
 		Assert.state(!this.consumerConfigurations.isEmpty(), "At least one 'Consumer' must be specified.");
 		return this.kafkaHighLevelConsumerMessageSource;
 	}

--- a/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/ftp/FtpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/integration/dsl/test/http/HttpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/http/HttpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors
+ * Copyright 2015-2016 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfigurati
 import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.boot.test.context.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.web.WebIntegrationTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.IntegrationTest;
+import org.springframework.boot.test.context.SpringApplicationConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.IntegrationTest;
+import org.springframework.boot.test.context.SpringApplicationConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The Spring Boot 1.4 has deprecated and moved some classes to different packages.
There are a lot of compiler warning when we build with Gradle.

* Upgrade `sonareqube` plugin
* Fix Spring Boot deprecation warnings
* Fix `rawtypes` warning for recently introduced classes for Kafka-0.9
* Fix deprecation warnings from the latest Spring Integration.
* Fix JavaDocs warnings.