### PR TITLE
Optimize `Tuple`s

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/support/tuple/Tuple.java
+++ b/src/main/java/org/springframework/integration/dsl/support/tuple/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,8 @@ package org.springframework.integration.dsl.support.tuple;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
-
-import org.springframework.util.Assert;
+import java.util.List;
 
 /**
  * A {@literal Tuple} is an immutable {@link java.util.Collection} of objects,
@@ -29,60 +27,49 @@ import org.springframework.util.Assert;
  *
  * @author Jon Brisbin
  * @author Stephane Maldini
+ * @author Artem Bilan
  */
-@SuppressWarnings({"rawtypes"})
-public class Tuple implements Iterable, Serializable {
+public class Tuple implements Iterable<Object>, Serializable {
 
 	private static final long serialVersionUID = 8777121214502020842L;
 
-	protected final Object[] entries;
+	static final Object[] emptyArray       = new Object[0];
+	static final Tuple    empty            = new Tuple(0);
+
 
 	protected final int size;
 
 	/**
 	 * Creates a new {@code Tuple} that holds the given {@code values}.
-	 *
-	 * @param values The values to hold
+	 * @param size The number of values to hold
 	 */
-	public Tuple(Collection<Object> values) {
-		Assert.notEmpty(values);
-		this.entries = values.toArray();
-		this.size = entries.length;
-	}
-
-	/**
-	 * Creates a new {@code Tuple} that holds the given {@code values}.
-	 *
-	 * @param values The values to hold
-	 */
-	public Tuple(Object... values) {
-		this.entries = Arrays.copyOf(values, values.length);
-		this.size = values.length;
+	protected Tuple(int size) {
+		this.size = size;
 	}
 
 
-	/**
-	 * Get the object at the given index.
-	 *
-	 * @param index The index of the object to retrieve. Starts at 0.
-	 * @return The object. Might be {@literal null}.
-	 */
 	public Object get(int index) {
-		return (size > 0 && size > index ? entries[index] : null);
+		return null;
 	}
 
 	/**
 	 * Turn this {@literal Tuple} into a plain Object array.
-	 *
 	 * @return A new Object array.
 	 */
 	public Object[] toArray() {
-		return entries;
+		return emptyArray;
+	}
+
+	/**
+	 * Turn this {@literal Tuple} into a plain Object list.
+	 * @return A new Object list.
+	 */
+	public List<Object> toList() {
+		return Arrays.asList(toArray());
 	}
 
 	/**
 	 * Return the number of elements in this {@literal Tuple}.
-	 *
 	 * @return The size of this {@literal Tuple}.
 	 */
 	public int size() {
@@ -90,44 +77,26 @@ public class Tuple implements Iterable, Serializable {
 	}
 
 	@Override
-	public Iterator<?> iterator() {
-		return Arrays.asList(entries).iterator();
-	}
-
-
-	@Override
-	public int hashCode() {
-		if (this.size == 0) {
-			return 0;
-		}
-		else if (this.size == 1) {
-			return this.entries[0].hashCode();
-		}
-		else {
-			int hashCode = 1;
-			for (Object entry : this.entries) {
-				hashCode = hashCode ^ entry.hashCode();
-			}
-			return hashCode;
-		}
+	public Iterator<Object> iterator() {
+		return toList().iterator();
 	}
 
 	@Override
 	public boolean equals(Object o) {
-		if (o == null) return false;
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
 
-		if (!(o instanceof Tuple)) return false;
+		Tuple tuple = (Tuple) o;
 
-		Tuple cast = (Tuple) o;
+		return this.size == tuple.size;
 
-		if (this.size != cast.size) return false;
+	}
 
-		for (int i = 0; i < this.size; i++) {
-			if (!this.entries[i].equals(cast.entries[i])) {
-				return false;
-			}
-		}
-		return true;
+	@Override
+	public int hashCode() {
+		return this.size;
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/support/tuple/Tuple1.java
+++ b/src/main/java/org/springframework/integration/dsl/support/tuple/Tuple1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,23 +22,68 @@ package org.springframework.integration.dsl.support.tuple;
  * @param <T1> The type held by this tuple
  *
  * @author Jon Brisbin
+ * @author Artem Bilan
  */
 public class Tuple1<T1> extends Tuple {
 
 	private static final long serialVersionUID = -1467756857377152573L;
 
-	Tuple1(Object... values) {
-		super(values);
+	public final T1 t1;
+
+	Tuple1(int size, T1 t1) {
+		super(1);
+		this.t1 = t1;
 	}
 
 	/**
 	 * Type-safe way to get the first object of this {@link Tuple}.
-	 *
 	 * @return The first object, cast to the correct type.
 	 */
-	@SuppressWarnings("unchecked")
 	public T1 getT1() {
-		return (T1) get(0);
+		return this.t1;
+	}
+
+	@Override
+	public Object get(int index) {
+		switch (index) {
+			case 0:
+				return t1;
+			default:
+				return null;
+		}
+	}
+
+	@Override
+	public Object[] toArray() {
+		return new Object[] {this.t1};
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		if (!super.equals(o))
+			return false;
+
+		Tuple1<?> tuple1 = (Tuple1<?>) o;
+
+		return this.t1 != null ? this.t1.equals(tuple1.t1) : tuple1.t1 == null;
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (this.t1 != null ? t1.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() +
+				(t1 != null ? "," + t1.toString() : "");
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/support/tuple/Tuple2.java
+++ b/src/main/java/org/springframework/integration/dsl/support/tuple/Tuple2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,23 +23,70 @@ package org.springframework.integration.dsl.support.tuple;
  * @param <T2> The type of the second value held by this tuple
  *
  * @author Jon Brisbin
+ * @author Artem Bilan
  */
 public class Tuple2<T1, T2> extends Tuple1<T1> {
 
 	private static final long serialVersionUID = -565933838909569191L;
 
-	Tuple2(Object... values) {
-		super(values);
+	public final T2 t2;
+
+	Tuple2(int size, T1 t1, T2 t2) {
+		super(2, t1);
+		this.t2 = t2;
 	}
 
 	/**
 	 * Type-safe way to get the second object of this {@link Tuple}.
-	 *
 	 * @return The second object, cast to the correct type.
 	 */
-	@SuppressWarnings("unchecked")
 	public T2 getT2() {
-		return (T2) get(1);
+		return this.t2;
+	}
+
+	@Override
+	public Object get(int index) {
+		switch (index) {
+			case 0:
+				return t1;
+			case 1:
+				return t2;
+			default:
+				return null;
+		}
+	}
+
+	@Override
+	public Object[] toArray() {
+		return new Object[]{this.t1, this.t2};
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		if (!super.equals(o))
+			return false;
+
+		Tuple2<?, ?> tuple2 = (Tuple2<?, ?>) o;
+
+		return this.t2 != null ? this.t2.equals(tuple2.t2) : tuple2.t2 == null;
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (this.t2 != null ? this.t2.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() +
+				(this.t2 != null ? "," + this.t2.toString() : "");
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/support/tuple/Tuples.java
+++ b/src/main/java/org/springframework/integration/dsl/support/tuple/Tuples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public abstract class Tuples {
 	 * @return The new {@link Tuple1}.
 	 */
 	public static <T1> Tuple1<T1> of(T1 t1) {
-		return new Tuple1<T1>(t1);
+		return new Tuple1<T1>(1, t1);
 	}
 
 	/**
@@ -41,7 +41,15 @@ public abstract class Tuples {
 	 * @return The new {@link Tuple2}.
 	 */
 	public static <T1, T2> Tuple2<T1, T2> of(T1 t1, T2 t2) {
-		return new Tuple2<T1, T2>(t1, t2);
+		return new Tuple2<T1, T2>(2, t1, t2);
 	}
+
+	/**
+	 * @return An empty tuple
+	 */
+	public static Tuple empty() {
+		return Tuple.empty;
+	}
+
 
 }


### PR DESCRIPTION
Previously the `Tuple` implementation has been based on the `Object[] entries`
representation for the values.
That is a bit suboptimal from the memory allocating perspective.
Plus that add some micro overhead during index accessing for items.

Change the `Tuple1` and `Tuple2` to be as simple POJO with properties for better memory
consumption and runtime usage.