### PR TITLE
GH-70: Add `log()` operator

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -2705,14 +2705,13 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @since 1.2
 	 */
 	public B log(LoggingHandler.Level level, String category, Expression logExpression) {
-		Assert.notNull(level);
-		LoggingHandler loggingHandler = new LoggingHandler(level.name());
+		LoggingHandler loggingHandler = new LoggingHandler(level);
 		if (StringUtils.hasText(category)) {
 			loggingHandler.setLoggerName(category);
 		}
 
 		if (logExpression != null) {
-			// TODO loggingHandler.setExpression(logExpression);
+			loggingHandler.setLogExpression(logExpression);
 		}
 		else {
 			loggingHandler.setShouldLogFullMessage(true);

--- a/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ import org.springframework.integration.handler.AbstractReplyProducingMessageHand
 import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.handler.DelayHandler;
 import org.springframework.integration.handler.ExpressionCommandMessageProcessor;
+import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -2502,6 +2503,226 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 		addComponent(flowBuilder.get());
 		return gateway(requestChannel, endpointConfigurer);
 	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the {@code INFO}
+	 * logging level and {@code org.springframework.integration.handler.LoggingHandler}
+	 * as a default logging category.
+	 * <p> The full request {@link Message} will be logged.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log() {
+		return log(LoggingHandler.Level.INFO);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for provided {@link LoggingHandler.Level}
+	 * logging level and {@code org.springframework.integration.handler.LoggingHandler}
+	 * as a default logging category.
+	 * <p> The full request {@link Message} will be logged.
+	 * @param level the {@link LoggingHandler.Level}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(LoggingHandler.Level level) {
+		return log(level, (String) null);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided logging category
+	 * and {@code INFO} logging level.
+	 * <p> The full request {@link Message} will be logged.
+	 * @param category the logging category to use.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(String category) {
+		return log(LoggingHandler.Level.INFO, category);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided
+	 * {@link LoggingHandler.Level} logging level and logging category.
+	 * <p> The full request {@link Message} will be logged.
+	 * @param level the {@link LoggingHandler.Level}.
+	 * @param category the logging category to use.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(LoggingHandler.Level level, String category) {
+		return log(level, category, (Expression) null);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided
+	 * {@link LoggingHandler.Level} logging level, logging category
+	 * and SpEL expression for the log message.
+	 * @param level the {@link LoggingHandler.Level}.
+	 * @param category the logging category.
+	 * @param logExpression the SpEL expression to evaluate logger message at runtime
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(LoggingHandler.Level level, String category, String logExpression) {
+		Assert.hasText(logExpression);
+		return log(level, category, PARSER.parseExpression(logExpression));
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the {@code INFO} logging level,
+	 * the {@code org.springframework.integration.handler.LoggingHandler}
+	 * as a default logging category and {@link Function} for the log message.
+	 * @param function the function to evaluate logger message at runtime
+	 * @param <P> the expected payload type.
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public <P> B log(Function<Message<P>, Object> function) {
+		Assert.notNull(function);
+		return log(new FunctionExpression<Message<P>>(function));
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the {@code INFO} logging level,
+	 * the {@code org.springframework.integration.handler.LoggingHandler}
+	 * as a default logging category and SpEL expression to evaluate
+	 * logger message at runtime against the request {@link Message}.
+	 * @param logExpression the {@link Expression} to evaluate logger message at runtime
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(Expression logExpression) {
+		return log(LoggingHandler.Level.INFO, logExpression);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided
+	 * {@link LoggingHandler.Level} logging level,
+	 * the {@code org.springframework.integration.handler.LoggingHandler}
+	 * as a default logging category and SpEL expression to evaluate
+	 * logger message at runtime against the request {@link Message}.
+	 * @param level the {@link LoggingHandler.Level}.
+	 * @param logExpression the {@link Expression} to evaluate logger message at runtime
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(LoggingHandler.Level level, Expression logExpression) {
+		return log(level, null, logExpression);
+	}
+
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the {@code INFO}
+	 * {@link LoggingHandler.Level} logging level,
+	 * the provided logging category and SpEL expression to evaluate
+	 * logger message at runtime against the request {@link Message}.
+	 * @param category the logging category.
+	 * @param logExpression the {@link Expression} to evaluate logger message at runtime
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(String category, Expression logExpression) {
+		return log(LoggingHandler.Level.INFO, category, logExpression);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided
+	 * {@link LoggingHandler.Level} logging level,
+	 * the {@code org.springframework.integration.handler.LoggingHandler}
+	 * as a default logging category and {@link Function} for the log message.
+	 * @param level the {@link LoggingHandler.Level}.
+	 * @param function the function to evaluate logger message at runtime
+	 * @param <P> the expected payload type.
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public <P> B log(LoggingHandler.Level level, Function<Message<P>, Object> function) {
+		return log(level, null, function);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided
+	 * {@link LoggingHandler.Level} logging level,
+	 * the provided logging category and {@link Function} for the log message.
+	 * @param category the logging category.
+	 * @param function the function to evaluate logger message at runtime
+	 * @param <P> the expected payload type.
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public <P> B log(String category, Function<Message<P>, Object> function) {
+		return log(LoggingHandler.Level.INFO, category, function);
+	}
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided
+	 * {@link LoggingHandler.Level} logging level, logging category
+	 * and {@link Function} for the log message.
+	 * @param level the {@link LoggingHandler.Level}.
+	 * @param category the logging category.
+	 * @param function the function to evaluate logger message at runtime
+	 * @param <P> the expected payload type.
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public <P> B log(LoggingHandler.Level level, String category, Function<Message<P>, Object> function) {
+		Assert.notNull(function);
+		return log(level, category, new FunctionExpression<Message<P>>(function));
+	}
+
+
+	/**
+	 * Populate a {@link WireTap} for the {@link #currentMessageChannel}
+	 * with the {@link LoggingHandler} subscriber for the provided
+	 * {@link LoggingHandler.Level} logging level, logging category
+	 * and SpEL expression for the log message.
+	 * @param level the {@link LoggingHandler.Level}.
+	 * @param category the logging category.
+	 * @param logExpression the {@link Expression} to evaluate logger message at runtime
+	 * against the request {@link Message}.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 1.2
+	 */
+	public B log(LoggingHandler.Level level, String category, Expression logExpression) {
+		Assert.notNull(level);
+		LoggingHandler loggingHandler = new LoggingHandler(level.name());
+		if (StringUtils.hasText(category)) {
+			loggingHandler.setLoggerName(category);
+		}
+
+		if (logExpression != null) {
+			// TODO loggingHandler.setExpression(logExpression);
+		}
+		else {
+			loggingHandler.setShouldLogFullMessage(true);
+		}
+
+		addComponent(loggingHandler);
+		MessageChannel loggerChannel = new FixedSubscriberChannel(loggingHandler);
+		return wireTap(loggerChannel);
+	}
+
 
 	/**
 	 * Represent an Integration Flow as a Reactive Streams {@link Publisher} bean.

--- a/src/test/java/org/springframework/integration/dsl/samples/file2file2/FileChangeLineSeparator.java
+++ b/src/test/java/org/springframework/integration/dsl/samples/file2file2/FileChangeLineSeparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,34 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.dsl.samples.file2file2;
 
 import java.io.File;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.core.Pollers;
 import org.springframework.integration.dsl.file.Files;
 import org.springframework.integration.dsl.support.Transformers;
 import org.springframework.integration.handler.LoggingHandler;
-import org.springframework.messaging.MessageHandler;
 
 /**
  * Simple file to file, converting CRLF to LF, with logging
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 1.1
  *
  */
-@Configuration
-@EnableIntegration
-@EnableAutoConfiguration
+@SpringBootApplication
 public class FileChangeLineSeparator {
 
 	public static void main(String[] args) throws Exception {
@@ -66,16 +63,9 @@ public class FileChangeLineSeparator {
 				.publishSubscribeChannel(c -> c
 						.subscribe(s -> s.handle(Files.outboundAdapter("'/tmp/out'")
 								.autoCreateDirectory(true)))
-						.subscribe(s -> s.handle(logger())))
+						.subscribe(s -> s.log(LoggingHandler.Level.WARN, null,
+								"headers['file_originalFile'].absolutePath + ' transferred'")))
 				.get();
 	}
-
-	@Bean
-	public MessageHandler logger() {
-		LoggingHandler handler = new LoggingHandler("WARN");
-		handler.setExpression("headers['file_originalFile'].absolutePath + ' transferred'");
-		return handler;
-	}
-
 
 }

--- a/src/test/java/org/springframework/integration/dsl/test/http/HttpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/http/HttpTests.java
@@ -29,8 +29,7 @@ import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfigurati
 import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
-import org.springframework.boot.test.context.SpringApplicationConfiguration;
-import org.springframework.boot.test.context.SpringApplicationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -50,8 +49,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  * @since 1.1
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration
-@SpringApplicationTest(webEnvironment = SpringApplicationTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class HttpTests {
 
 	@Value("${local.server.port}")

--- a/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
@@ -32,8 +32,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.test.context.SpringApplicationConfiguration;
-import org.springframework.boot.test.context.SpringApplicationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -54,10 +53,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Artem Bilan
  */
-@SpringApplicationConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
-@SpringApplicationTest
+@SpringBootTest
 public class JdbcTests {
 
 	@Autowired

--- a/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
@@ -27,8 +27,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
-import org.springframework.boot.test.context.SpringApplicationConfiguration;
-import org.springframework.boot.test.context.SpringApplicationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -54,10 +53,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Artem Bilan
  */
-@SpringApplicationConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
-@SpringApplicationTest
+@SpringBootTest
 public class MongoDbTests {
 
 	@Autowired

--- a/src/test/java/org/springframework/integration/dsl/test/xml/XmlTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/xml/XmlTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors
+ * Copyright 2015-2016 the original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,22 @@
 package org.springframework.integration.dsl.test.xml;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import org.apache.commons.logging.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.internal.stubbing.answers.DoesNothing;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +40,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
@@ -38,12 +48,15 @@ import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.support.FunctionExpression;
 import org.springframework.integration.dsl.support.Transformers;
 import org.springframework.integration.dsl.support.tuple.Tuples;
+import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xml.router.XPathRouter;
 import org.springframework.integration.xml.selector.StringValueTestXPathMessageSelector;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
@@ -74,8 +87,26 @@ public class XmlTests {
 	@Autowired
 	private PollableChannel receivedChannel;
 
+	@Autowired
+	private FixedSubscriberChannel loggingChannel;
+
 	@Test
 	public void testXpathFlow() {
+		assertNotNull(this.loggingChannel);
+		MessageHandler handler = TestUtils.getPropertyValue(this.loggingChannel, "handler", MessageHandler.class);
+		assertThat(handler, instanceOf(LoggingHandler.class));
+		assertEquals(LoggingHandler.Level.ERROR,
+				TestUtils.getPropertyValue(handler, "level", LoggingHandler.Level.class));
+
+		Log messageLogger = TestUtils.getPropertyValue(handler, "messageLogger", Log.class);
+		assertEquals("test.category", TestUtils.getPropertyValue(messageLogger, "name"));
+
+		messageLogger = spy(messageLogger);
+
+		willAnswer(new DoesNothing()).given(messageLogger).error(anyString());
+
+		new DirectFieldAccessor(handler).setPropertyValue("messageLogger", messageLogger);
+
 		this.inputChannel.send(new GenericMessage<>("<foo/>"));
 		assertNotNull(this.wrongMessagesChannel.receive(10000));
 
@@ -87,6 +118,8 @@ public class XmlTests {
 
 		this.inputChannel.send(new GenericMessage<>("<Tag xmlns=\"my:namespace\"/>"));
 		assertNotNull(this.receivedChannel.receive(10000));
+
+		verify(messageLogger, times(3)).error(anyString());
 	}
 
 	@Test
@@ -122,6 +155,8 @@ public class XmlTests {
 			return IntegrationFlows.from("inputChannel")
 					.filter(new StringValueTestXPathMessageSelector("namespace-uri(/*)", "my:namespace"),
 							e -> e.discardChannel(wrongMessagesChannel()))
+					.log(LoggingHandler.Level.ERROR, "test.category",
+							m -> m.getHeaders().getId() + ": " + m.getPayload())
 					.route(xpathRouter())
 					.get();
 		}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootCategory=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d %c{1} [%t] : %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d %5p %c{1} [%t] : %m%n
 
 log4j.category.org.springframework=WARN
 log4j.category.org.springframework.integration.dsl=WARN


### PR DESCRIPTION
Fixes GH-70 (https://github.com/spring-projects/spring-integration-java-dsl/issues/70)

And an implicit `WireTap` with `LoggingHandler` subscriber for tapped `FixedSubscriberChannel`
to allow easy log an intermediate message via fluent API. For example:

````java
return f -> f
	.filter(...)
	.log()
	.handle(...);
````