### PR TITLE
GH-72: align File filtering logic with SI Core

### DIFF
--- a/src/test/java/org/springframework/integration/dsl/test/http/HttpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/http/HttpTests.java
@@ -29,8 +29,7 @@ import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfigurati
 import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
-import org.springframework.boot.test.context.SpringApplicationConfiguration;
-import org.springframework.boot.test.context.SpringApplicationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -50,8 +49,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  * @since 1.1
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration
-@SpringApplicationTest(webEnvironment = SpringApplicationTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class HttpTests {
 
 	@Value("${local.server.port}")

--- a/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jdbc/JdbcTests.java
@@ -32,8 +32,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.test.context.SpringApplicationConfiguration;
-import org.springframework.boot.test.context.SpringApplicationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -54,10 +53,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Artem Bilan
  */
-@SpringApplicationConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
-@SpringApplicationTest
+@SpringBootTest
 public class JdbcTests {
 
 	@Autowired

--- a/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mongodb/MongoDbTests.java
@@ -27,8 +27,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
-import org.springframework.boot.test.context.SpringApplicationConfiguration;
-import org.springframework.boot.test.context.SpringApplicationTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -54,10 +53,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Artem Bilan
  */
-@SpringApplicationConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
-@SpringApplicationTest
+@SpringBootTest
 public class MongoDbTests {
 
 	@Autowired


### PR DESCRIPTION
Fixes: GH-72 (https://github.com/spring-projects/spring-integration-java-dsl/issues/72)

The previous logic with just a direct `ignoreDuplicates()` prevented the `ignoreHidden` filter being added,
like it assumes by default logic.

* Replace an internal filters logic in the `FileInboundChannelAdapterSpec` into the
`FileListFilterFactoryBean` from the SI Core.
`FileListFilterFactoryBean` allows us still rely on the default `ignoreHidden = Boolean.TRUE`,
meanwhile don't use `AcceptOnceFileListFilter` but `AcceptAllFileListFilter`
via `FileInboundChannelAdapterSpec#preventDuplicates(false)`

**Cherry-pick to the 1.1.x only `FileInboundChannelAdapterSpec` changes**