### PR TITLE
GH-81: Fix Jms components to propagate channel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ ext {
 	activeMqVersion = '5.13.2'
 	apacheSshdVersion = '1.1.0'
 	commonsDbcpVersion = '1.4'
+	commonsHttpClientVersion = '4.5.2'
 	embedMongoVersion = '1.50.2'
 	ftpServerVersion = '1.0.6'
 	hsqldbVersion = '2.3.3'
@@ -134,6 +135,8 @@ dependencies {
 		optional it
 		exclude group: 'org.apache.tomcat.embed', module: 'tomcat-embed-jasper'
 		exclude group: 'org.apache.tomcat.embed', module: 'tomcat-embed-logging-juli'
+		exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+		exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
 	}
 
 	compile("javax.jms:jms-api:$jmsApiVersion", provided)
@@ -170,6 +173,7 @@ dependencies {
 	testRuntime "org.jruby:jruby:$jrubyVersion"
 	testRuntime "org.python:jython-standalone:$jythonVersion"
 	testRuntime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatVersion"
+	testRuntime "org.apache.httpcomponents:httpclient:$commonsHttpClientVersion"
 }
 
 // enable all compiler warnings; individual projects may customize further

--- a/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
+++ b/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
@@ -331,13 +331,7 @@ public final class IntegrationFlows {
 	 * @return new {@link IntegrationFlowBuilder}.
 	 */
 	public static IntegrationFlowBuilder from(MessagingGatewaySupport inboundGateway) {
-		DirectFieldAccessor dfa = new DirectFieldAccessor(inboundGateway);
-		MessageChannel outputChannel = (MessageChannel) dfa.getPropertyValue("requestChannel");
-		if (outputChannel == null) {
-			outputChannel = new DirectChannel();
-			inboundGateway.setRequestChannel(outputChannel);
-		}
-		return from(outputChannel).addComponent(inboundGateway);
+		return from(inboundGateway, (IntegrationFlowBuilder) null);
 	}
 
 	private static IntegrationFlowBuilder from(MessagingGatewaySupport inboundGateway,
@@ -369,15 +363,19 @@ public final class IntegrationFlows {
 	}
 
 	public interface ChannelsFunction extends Function<Channels, MessageChannelSpec<?, ?>> {
+
 	}
 
 	public interface MessageSourcesFunction extends Function<MessageSources, MessageSourceSpec<?, ?>> {
+
 	}
 
 	public interface MessageProducersFunction extends Function<MessageProducers, MessageProducerSpec<?, ?>> {
+
 	}
 
 	public interface MessagingGatewaysFunction extends Function<MessagingGateways, MessagingGatewaySpec<?, ?>> {
+
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/jms/JmsInboundGateway.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/JmsInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ public class JmsInboundGateway extends MessagingGatewaySupport implements
 
 	@Override
 	public void setRequestChannel(MessageChannel requestChannel) {
+		super.setRequestChannel(requestChannel);
 		this.listener.setRequestChannel(requestChannel);
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/jms/JmsMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/JmsMessageDrivenChannelAdapter.java
@@ -44,6 +44,7 @@ public class JmsMessageDrivenChannelAdapter extends MessageProducerSupport imple
 
 	@Override
 	public void setOutputChannel(MessageChannel requestChannel) {
+		super.setOutputChannel(requestChannel);
 		this.listener.setRequestChannel(requestChannel);
 	}
 

--- a/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.PostConstruct;
@@ -31,6 +32,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -119,6 +121,12 @@ public class JmsTests {
 	@Qualifier("jmsOutboundGateway.handler")
 	private MessageHandler jmsOutboundGatewayHandler;
 
+	@Autowired
+	private AtomicBoolean jmsMessageDriverChannelCalled;
+
+	@Autowired
+	private AtomicBoolean jmsInboundGatewayChannelCalled;
+
 	@Test
 	public void testPollingFlow() {
 		this.controlBus.send("@'jmsTests.ContextConfiguration.integerMessageSource.inboundChannelAdapter'.start()");
@@ -142,7 +150,7 @@ public class JmsTests {
 				.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "jmsInbound")
 				.build());
 
-		Message<?> receive = this.jmsOutboundInboundReplyChannel.receive(5000);
+		Message<?> receive = this.jmsOutboundInboundReplyChannel.receive(10000);
 
 		assertNotNull(receive);
 		assertEquals("HELLO THROUGH THE JMS", receive.getPayload());
@@ -151,16 +159,18 @@ public class JmsTests {
 				.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "jmsMessageDriver")
 				.build());
 
-		receive = this.jmsOutboundInboundReplyChannel.receive(5000);
+		receive = this.jmsOutboundInboundReplyChannel.receive(10000);
 
 		assertNotNull(receive);
 		assertEquals("hello through the jms", receive.getPayload());
+
+		assertTrue(this.jmsMessageDriverChannelCalled.get());
 
 		this.jmsOutboundInboundChannel.send(MessageBuilder.withPayload("    foo    ")
 				.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "containerSpecDestination")
 				.build());
 
-		receive = this.jmsOutboundInboundReplyChannel.receive(5000);
+		receive = this.jmsOutboundInboundReplyChannel.receive(10000);
 
 		assertNotNull(receive);
 		assertEquals("foo", receive.getPayload());
@@ -181,6 +191,8 @@ public class JmsTests {
 
 		assertNotNull(receive);
 		assertEquals("HELLO THROUGH THE JMS PIPELINE", receive.getPayload());
+
+		assertTrue(this.jmsInboundGatewayChannelCalled.get());
 	}
 
 	@Test
@@ -202,7 +214,7 @@ public class JmsTests {
 	}
 
 	@Configuration
-	@Import({ActiveMQAutoConfiguration.class, JmxAutoConfiguration.class, IntegrationAutoConfiguration.class})
+	@Import({ ActiveMQAutoConfiguration.class, JmxAutoConfiguration.class, IntegrationAutoConfiguration.class })
 	@IntegrationComponentScan
 	@ComponentScan
 	public static class ContextConfiguration {
@@ -276,10 +288,31 @@ public class JmsTests {
 		public IntegrationFlow jmsMessageDrivenFlow() {
 			return IntegrationFlows
 					.from(Jms.messageDrivenChannelAdapter(this.jmsConnectionFactory)
+							.outputChannel(jmsMessageDriverInputChannel())
 							.destination("jmsMessageDriver"))
 					.<String, String>transform(String::toLowerCase)
 					.channel(jmsOutboundInboundReplyChannel())
 					.get();
+		}
+
+		@Bean
+		public AtomicBoolean jmsMessageDriverChannelCalled() {
+			return new AtomicBoolean();
+		}
+
+		@Bean
+		public MessageChannel jmsMessageDriverInputChannel() {
+			DirectChannel directChannel = new DirectChannel();
+			directChannel.addInterceptor(new ChannelInterceptorAdapter() {
+
+				@Override
+				public Message<?> preSend(Message<?> message, MessageChannel channel) {
+					jmsMessageDriverChannelCalled().set(true);
+					return super.preSend(message, channel);
+				}
+
+			});
+			return directChannel;
 		}
 
 		@Bean
@@ -297,9 +330,9 @@ public class JmsTests {
 		@Bean
 		public IntegrationFlow jmsOutboundGatewayFlow() {
 			return f -> f.handleWithAdapter(a ->
-					a.jmsGateway(this.jmsConnectionFactory)
-							.replyContainer(c -> c.idleReplyContainerTimeout(10))
-							.requestDestination("jmsPipelineTest"),
+							a.jmsGateway(this.jmsConnectionFactory)
+									.replyContainer(c -> c.idleReplyContainerTimeout(10))
+									.requestDestination("jmsPipelineTest"),
 					e -> e.id("jmsOutboundGateway"));
 		}
 
@@ -307,9 +340,30 @@ public class JmsTests {
 		public IntegrationFlow jmsInboundGatewayFlow() {
 			return IntegrationFlows.from((MessagingGateways g) ->
 					g.jms(this.jmsConnectionFactory)
+							.requestChannel(jmsInboundGatewayInputChannel())
 							.destination("jmsPipelineTest"))
 					.<String, String>transform(String::toUpperCase)
 					.get();
+		}
+
+		@Bean
+		public AtomicBoolean jmsInboundGatewayChannelCalled() {
+			return new AtomicBoolean();
+		}
+
+		@Bean
+		public MessageChannel jmsInboundGatewayInputChannel() {
+			DirectChannel directChannel = new DirectChannel();
+			directChannel.addInterceptor(new ChannelInterceptorAdapter() {
+
+				@Override
+				public Message<?> preSend(Message<?> message, MessageChannel channel) {
+					jmsInboundGatewayChannelCalled().set(true);
+					return super.preSend(message, channel);
+				}
+
+			});
+			return directChannel;
 		}
 
 	}


### PR DESCRIPTION
Fixes GH-81 (https://github.com/spring-projects/spring-integration-java-dsl/issues/81)

The `JmsInboundGateway` and `JmsMessageDrivenChannelAdapter` delegates their logic to an internal `ChannelPublishingJmsMessageListener`.
The `requestChannel` (`outputChannel`) is one of those options.
The `IntegrationFlows.from(MessagingGatewaySupport)` and `IntegrationFlows.from(MessageProducerSupport)` logic is based on the fact we have provided
`requestChannel` (`outputChannel`) or not.
Since `JmsInboundGateway` and `JmsMessageDrivenChannelAdapter` don't care about `requestChannel` (`outputChannel`) exposition, we ended up with
inconsistent behavior when `IntegrationFlows.from()` overrode user-provided channel.

* Fix `JmsInboundGateway` and `JmsMessageDrivenChannelAdapter` to store `requestChannel` (`outputChannel`) in the appropriate property to meet `IntegrationFlows.from()` logic
* Modify `JmsTests` to reflect the fix
* Add `testRuntime "org.apache.httpcomponents:httpclient:$commonsHttpClientVersion"` dependency for Spring Boot 1.4 compatibility

**Cherry-pick to 1.1.x**