### PR TITLE
GH-84: Fix the double usage of the `AMPHandler`

### DIFF
--- a/src/test/java/org/springframework/integration/dsl/test/flows/IntegrationFlowTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/flows/IntegrationFlowTests.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -1101,7 +1102,6 @@ public class IntegrationFlowTests {
 		}
 
 		@Bean
-		@DependsOn("gatewayRequestFlow")
 		public IntegrationFlow gatewayFlow() {
 			return IntegrationFlows.from("gatewayInput")
 					.gateway("gatewayRequest", g -> g.errorChannel("gatewayError").replyTimeout(10L))

--- a/src/test/java/org/springframework/integration/dsl/test/handlers/MessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/handlers/MessageHandlerTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.test.handlers;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+
+/**
+ * @author Artem Bilan
+ * @since 1.2
+ */
+public class MessageHandlerTests {
+
+	@Test
+	public void testWrongReuseOfAbstractMessageProducingHandler() {
+		try {
+			new AnnotationConfigApplicationContext(InvalidReuseOfAbstractMessageProducingHandlerContext.class).close();
+			fail("BeanCreationException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(BeanCreationException.class));
+			assertThat(e.getMessage(),
+					containsString("An AbstractMessageProducingHandler may only be referenced once"));
+		}
+	}
+
+	@Configuration
+	public static class InvalidReuseOfAbstractMessageProducingHandlerContext {
+
+		@Bean
+		public IntegrationFlow wrongReuseOfAbstractMessageProducingHandler() {
+			return IntegrationFlows.from("foo")
+					.handle(testHandler())
+					.handle(testHandler())
+					.log()
+					.get();
+		}
+
+		@Bean
+		public MessageHandler testHandler() {
+			return new AbstractMessageProducingHandler() {
+
+				@Override
+				protected void handleMessageInternal(Message<?> message) throws Exception {
+
+				}
+
+			};
+		}
+
+	}
+
+}


### PR DESCRIPTION
Fixes GH-84 (https://github.com/spring-projects/spring-integration-java-dsl/issues/84)

The same `AbstractMessageProducingHandler` can't be used from different endpoints,
its `outputChannel` may be overridden.
Detect such a situation and treat it as illegal state for the entire application