### PR TITLE
GH-83: Add `AsyncAmqpOutboundGateway` support

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/amqp/Amqp.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/Amqp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.dsl.amqp;
 
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 
@@ -163,6 +164,16 @@ public abstract class Amqp {
 	 */
 	public static AmqpOutboundEndpointSpec outboundGateway(AmqpTemplate amqpTemplate) {
 		return new AmqpOutboundEndpointSpec(amqpTemplate, true);
+	}
+
+	/**
+	 * Create an initial AmqpAsyncOutboundGatewaySpec.
+	 * @param asyncRabbitTemplate the {@link AsyncRabbitTemplate}.
+	 * @return the AmqpOutboundEndpointSpec.
+	 * @since 1.2
+	 */
+	public static AmqpAsyncOutboundGatewaySpec asyncOutboundGateway(AsyncRabbitTemplate asyncRabbitTemplate) {
+		return new AmqpAsyncOutboundGatewaySpec(asyncRabbitTemplate);
 	}
 
 	/**

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpAsyncOutboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpAsyncOutboundGatewaySpec.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.amqp;
+
+import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
+import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
+import org.springframework.integration.amqp.outbound.AsyncAmqpOutboundGateway;
+import org.springframework.integration.dsl.core.MessageHandlerSpec;
+
+/**
+ * @author Artem Bilan
+ * @since 1.2
+ */
+public class AmqpAsyncOutboundGatewaySpec
+		extends AmqpBaseOutboundEndpointSpec<AmqpAsyncOutboundGatewaySpec, AsyncAmqpOutboundGateway> {
+
+	AmqpAsyncOutboundGatewaySpec(AsyncRabbitTemplate template) {
+		this.target = new AsyncAmqpOutboundGateway(template);
+	}
+
+}

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpBaseOutboundEndpointSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpBaseOutboundEndpointSpec.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.amqp;
+
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.expression.Expression;
+import org.springframework.integration.amqp.outbound.AbstractAmqpOutboundEndpoint;
+import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
+import org.springframework.integration.amqp.support.AmqpHeaderMapper;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.dsl.core.MessageHandlerSpec;
+import org.springframework.integration.dsl.support.Function;
+import org.springframework.integration.dsl.support.FunctionExpression;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.util.Assert;
+
+/**
+ * @author Artem Bilan
+ * @since 1.2
+ */
+public abstract class AmqpBaseOutboundEndpointSpec<S extends AmqpBaseOutboundEndpointSpec<S, E>, E extends AbstractAmqpOutboundEndpoint>
+		extends MessageHandlerSpec<S, E> {
+
+	protected final DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.outboundMapper();
+
+	public S headerMapper(AmqpHeaderMapper headerMapper) {
+		this.target.setHeaderMapper(headerMapper);
+		return _this();
+	}
+
+	public S defaultDeliveryMode(MessageDeliveryMode defaultDeliveryMode) {
+		this.target.setDefaultDeliveryMode(defaultDeliveryMode);
+		return _this();
+	}
+
+	public S routingKey(String routingKey) {
+		this.target.setRoutingKey(routingKey);
+		return _this();
+	}
+
+	public S routingKeyExpression(String routingKeyExpression) {
+		return routingKeyExpression(PARSER.parseExpression(routingKeyExpression));
+	}
+
+	public S routingKeyFunction(Function<Message<?>, String> routingKeyFunction) {
+		return routingKeyExpression(new FunctionExpression<Message<?>>(routingKeyFunction));
+	}
+
+	public S routingKeyExpression(Expression routingKeyExpression) {
+		this.target.setRoutingKeyExpression(routingKeyExpression);
+		return _this();
+	}
+
+	public S returnChannel(MessageChannel returnChannel) {
+		this.target.setReturnChannel(returnChannel);
+		return _this();
+	}
+
+	public S confirmAckChannel(MessageChannel ackChannel) {
+		this.target.setConfirmAckChannel(ackChannel);
+		return _this();
+	}
+
+	public S exchangeName(String exchangeName) {
+		this.target.setExchangeName(exchangeName);
+		return _this();
+	}
+
+	public S exchangeNameExpression(String exchangeNameExpression) {
+		return exchangeNameExpression(PARSER.parseExpression(exchangeNameExpression));
+	}
+
+	public S exchangeNameFunction(Function<Message<?>, String> exchangeNameFunction) {
+		return exchangeNameExpression(new FunctionExpression<Message<?>>(exchangeNameFunction));
+	}
+
+	public S exchangeNameExpression(Expression exchangeNameExpression) {
+		this.target.setExchangeNameExpression(exchangeNameExpression);
+		return _this();
+	}
+
+	public S confirmNackChannel(MessageChannel nackChannel) {
+		this.target.setConfirmNackChannel(nackChannel);
+		return _this();
+	}
+
+	public S confirmCorrelationExpression(String confirmCorrelationExpression) {
+		return confirmCorrelationExpression(PARSER.parseExpression(confirmCorrelationExpression));
+	}
+
+	public S confirmCorrelationFunction(Function<Message<?>, Object> confirmCorrelationFunction) {
+		return confirmCorrelationExpression(new FunctionExpression<Message<?>>(confirmCorrelationFunction));
+	}
+
+
+	public S confirmCorrelationExpression(Expression confirmCorrelationExpression) {
+		this.target.setConfirmCorrelationExpression(confirmCorrelationExpression);
+		return _this();
+	}
+
+	public S mappedRequestHeaders(String... headers) {
+		this.headerMapper.setRequestHeaderNames(headers);
+		return _this();
+	}
+
+	public S mappedReplyHeaders(String... headers) {
+		this.headerMapper.setReplyHeaderNames(headers);
+		return _this();
+	}
+
+	@Override
+	protected E doGet() {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/amqp/AmqpOutboundEndpointSpec.java
@@ -28,92 +28,24 @@ import org.springframework.util.Assert;
 /**
  * @author Artem Bilan
  */
-public class AmqpOutboundEndpointSpec extends MessageHandlerSpec<AmqpOutboundEndpointSpec, AmqpOutboundEndpoint> {
-
-	private final AmqpOutboundEndpoint endpoint;
+public class AmqpOutboundEndpointSpec
+		extends AmqpBaseOutboundEndpointSpec<AmqpOutboundEndpointSpec, AmqpOutboundEndpoint> {
 
 	private final boolean expectReply;
 
-	private final DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.outboundMapper();
-
 	AmqpOutboundEndpointSpec(AmqpTemplate amqpTemplate, boolean expectReply) {
-		this.endpoint = new AmqpOutboundEndpoint(amqpTemplate);
 		this.expectReply = expectReply;
-		this.endpoint.setExpectReply(expectReply);
-		this.endpoint.setHeaderMapper(this.headerMapper);
+		this.target = new AmqpOutboundEndpoint(amqpTemplate);
+		this.target.setExpectReply(expectReply);
+		this.target.setHeaderMapper(this.headerMapper);
 		if (expectReply) {
-			this.endpoint.setRequiresReply(true);
+			this.target.setRequiresReply(true);
 		}
-	}
-
-	public AmqpOutboundEndpointSpec headerMapper(AmqpHeaderMapper headerMapper) {
-		endpoint.setHeaderMapper(headerMapper);
-		return this;
-	}
-
-	public AmqpOutboundEndpointSpec routingKey(String routingKey) {
-		endpoint.setRoutingKey(routingKey);
-		return this;
-	}
-
-	public AmqpOutboundEndpointSpec defaultDeliveryMode(MessageDeliveryMode defaultDeliveryMode) {
-		endpoint.setDefaultDeliveryMode(defaultDeliveryMode);
-		return this;
-	}
-
-	public AmqpOutboundEndpointSpec exchangeName(String exchangeName) {
-		endpoint.setExchangeName(exchangeName);
-		return this;
-	}
-
-	@SuppressWarnings("deprecation")
-	public AmqpOutboundEndpointSpec routingKeyExpression(String routingKeyExpression) {
-		endpoint.setExpressionRoutingKey(PARSER.parseExpression(routingKeyExpression));
-		return this;
-	}
-
-	public AmqpOutboundEndpointSpec returnChannel(MessageChannel returnChannel) {
-		endpoint.setReturnChannel(returnChannel);
-		return this;
-	}
-
-	public AmqpOutboundEndpointSpec confirmAckChannel(MessageChannel ackChannel) {
-		endpoint.setConfirmAckChannel(ackChannel);
-		return this;
-	}
-
-	@SuppressWarnings("deprecation")
-	public AmqpOutboundEndpointSpec exchangeNameExpression(String exchangeNameExpression) {
-		endpoint.setExpressionExchangeName(PARSER.parseExpression(exchangeNameExpression));
-		return this;
-	}
-
-	public AmqpOutboundEndpointSpec confirmNackChannel(MessageChannel nackChannel) {
-		endpoint.setConfirmNackChannel(nackChannel);
-		return this;
-	}
-
-	@SuppressWarnings("deprecation")
-	public AmqpOutboundEndpointSpec confirmCorrelationExpression(String confirmCorrelationExpression) {
-		endpoint.setExpressionConfirmCorrelation(PARSER.parseExpression(confirmCorrelationExpression));
-		return this;
-	}
-
-	public AmqpOutboundEndpointSpec mappedRequestHeaders(String... headers) {
-		this.headerMapper.setRequestHeaderNames(headers);
-		return this;
 	}
 
 	public AmqpOutboundEndpointSpec mappedReplyHeaders(String... headers) {
 		Assert.isTrue(expectReply, "'mappedReplyHeaders' can be applied only for gateway");
-		this.headerMapper.setReplyHeaderNames(headers);
-		return this;
-	}
-
-
-	@Override
-	protected AmqpOutboundEndpoint doGet() {
-		return this.endpoint;
+		return super.mappedReplyHeaders(headers);
 	}
 
 }


### PR DESCRIPTION
Fixes GH-83 (https://github.com/spring-projects/spring-integration-java-dsl/issues/83)

* Add `Amqp.asyncOutboundGateway()`
* Add `AmqpAsyncOutboundGatewaySpec`
* Extract `AmqpBaseOutboundEndpointSpec` for common outbound adapters options
* Add `Expression` and `Function` overloaded methods for `routingKey`, `exchangeName` and `confirmCorrelation`
* Add `AmqpTests.testAmqpAsyncOutboundGatewayFlow()`