### PR TITLE
GH-93: CorrSpecs: Properly instantiate strategies

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
@@ -173,8 +173,10 @@ public abstract class
 		try {
 			CorrelationStrategyFactoryBean correlationStrategyFactoryBean = new CorrelationStrategyFactoryBean();
 			correlationStrategyFactoryBean.setTarget(target);
+			correlationStrategyFactoryBean.afterPropertiesSet();
 			ReleaseStrategyFactoryBean releaseStrategyFactoryBean = new ReleaseStrategyFactoryBean();
 			releaseStrategyFactoryBean.setTarget(target);
+			releaseStrategyFactoryBean.afterPropertiesSet();
 			return correlationStrategy(correlationStrategyFactoryBean.getObject())
 					.releaseStrategy(releaseStrategyFactoryBean.getObject());
 		}
@@ -208,6 +210,7 @@ public abstract class
 			CorrelationStrategyFactoryBean correlationStrategyFactoryBean = new CorrelationStrategyFactoryBean();
 			correlationStrategyFactoryBean.setTarget(target);
 			correlationStrategyFactoryBean.setMethodName(methodName);
+			correlationStrategyFactoryBean.afterPropertiesSet();
 			return correlationStrategy(correlationStrategyFactoryBean.getObject());
 		}
 		catch (Exception e) {
@@ -250,6 +253,7 @@ public abstract class
 			ReleaseStrategyFactoryBean releaseStrategyFactoryBean = new ReleaseStrategyFactoryBean();
 			releaseStrategyFactoryBean.setTarget(target);
 			releaseStrategyFactoryBean.setMethodName(methodName);
+			releaseStrategyFactoryBean.afterPropertiesSet();
 			return releaseStrategy(releaseStrategyFactoryBean.getObject());
 		}
 		catch (Exception e) {

--- a/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.dsl.test.flowservices;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -35,7 +36,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.annotation.Aggregator;
+import org.springframework.integration.annotation.CorrelationStrategy;
 import org.springframework.integration.annotation.Filter;
+import org.springframework.integration.annotation.ReleaseStrategy;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
 import org.springframework.integration.annotation.Transformer;
@@ -149,7 +152,7 @@ public class FlowServiceTests {
 		@Override
 		protected IntegrationFlowDefinition<?> buildFlow() {
 			return from(this, "messageSource", e -> e.poller(p -> p.trigger(this::nextExecutionTime)))
-					.split(this)
+					.split(this, null, e -> e.applySequence(false))
 					.transform(this)
 					.aggregate(a -> a.processor(this, null))
 					.enrichHeaders(Collections.singletonMap("foo", "FOO"))
@@ -170,6 +173,17 @@ public class FlowServiceTests {
 		@Transformer
 		public String transform(String payload) {
 			return payload.toLowerCase();
+		}
+
+
+		@CorrelationStrategy
+		public Integer correlationKey() {
+			return 1;
+		}
+
+		@ReleaseStrategy
+		public boolean canRelease(Collection<Message<?>> messages) {
+			return messages.size() == 3;
 		}
 
 		@Aggregator


### PR DESCRIPTION
Fixes: GH-93 (https://github.com/spring-projects/spring-integration-java-dsl/issues/93)

Since Spring Integration  4.2.5 (https://jira.spring.io/browse/INT-3916), we have to call `afterPropertiesSet()`
for the `CorrelationStrategyFactoryBean` and `ReleaseStrategyFactoryBean` if we use them directly

**Cherry-pick to 1.1.x**