### PR TITLE
GH-95: Introduce JmsDefaultListenerContainerSpec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,10 @@ ext {
 	reactorVersion = '2.0.8.RELEASE'
 	scalaVersion = '2.10'
 	slf4jVersion = '1.7.21'
-	springIntegrationVersion = project.hasProperty('siVersion') ? project.siVersion : '4.3.0.RELEASE'
+	springIntegrationVersion = project.hasProperty('siVersion') ? project.siVersion : '4.3.1.BUILD-SNAPSHOT'
 	springIntegrationKafkaVersion = '1.3.1.RELEASE'
-	springKafkaVersion = '1.0.1.RELEASE'
-	springBootVersion = '1.4.0.RC1'
+	springKafkaVersion = '1.0.2.RELEASE'
+	springBootVersion = '1.4.0.BUILD-SNAPSHOT'
 	testNgVersion = '6.8.21'
 	tomcatVersion = '8.5.2'
 

--- a/src/main/java/org/springframework/integration/dsl/MessageProducers.java
+++ b/src/main/java/org/springframework/integration/dsl/MessageProducers.java
@@ -30,6 +30,7 @@ import org.springframework.integration.dsl.http.Http;
 import org.springframework.integration.dsl.http.HttpControllerEndpointSpec;
 import org.springframework.integration.dsl.http.HttpRequestHandlerEndpointSpec;
 import org.springframework.integration.dsl.jms.Jms;
+import org.springframework.integration.dsl.jms.JmsListenerContainerSpec;
 import org.springframework.integration.dsl.jms.JmsMessageDrivenChannelAdapterSpec;
 import org.springframework.integration.dsl.mail.ImapIdleChannelAdapterSpec;
 import org.springframework.integration.dsl.mail.Mail;
@@ -83,11 +84,11 @@ public class MessageProducers {
 		return Jms.messageDrivenChannelAdapter(connectionFactory);
 	}
 
-	public <C extends AbstractMessageListenerContainer>
+	public <S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
 	JmsMessageDrivenChannelAdapterSpec<? extends JmsMessageDrivenChannelAdapterSpec<?>> jms(
 			javax.jms.ConnectionFactory connectionFactory,
 			Class<C> containerClass) {
-		return Jms.messageDrivenChannelAdapter(connectionFactory, containerClass);
+		return Jms.<S, C>messageDrivenChannelAdapter(connectionFactory, containerClass);
 	}
 
 	public HttpControllerEndpointSpec http(String viewName, String... path) {

--- a/src/main/java/org/springframework/integration/dsl/MessagingGateways.java
+++ b/src/main/java/org/springframework/integration/dsl/MessagingGateways.java
@@ -29,7 +29,9 @@ import org.springframework.integration.dsl.http.Http;
 import org.springframework.integration.dsl.http.HttpControllerEndpointSpec;
 import org.springframework.integration.dsl.http.HttpRequestHandlerEndpointSpec;
 import org.springframework.integration.dsl.jms.Jms;
+import org.springframework.integration.dsl.jms.JmsDefaultListenerContainerSpec;
 import org.springframework.integration.dsl.jms.JmsInboundGatewaySpec;
+import org.springframework.integration.dsl.jms.JmsListenerContainerSpec;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
@@ -67,13 +69,13 @@ public class MessagingGateways {
 		return Amqp.inboundGateway(listenerContainer, amqpTemplate);
 	}
 
-	public JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<DefaultMessageListenerContainer> jms(
+	public JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer> jms(
 			javax.jms.ConnectionFactory connectionFactory) {
 		return Jms.inboundGateway(connectionFactory);
 	}
 
-	public <C extends AbstractMessageListenerContainer>
-	JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<C> jms(ConnectionFactory connectionFactory,
+	public <S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+	JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<S, C> jms(ConnectionFactory connectionFactory,
 			Class<C> containerClass) {
 		return Jms.inboundGateway(connectionFactory, containerClass);
 	}

--- a/src/main/java/org/springframework/integration/dsl/jms/Jms.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/Jms.java
@@ -163,7 +163,7 @@ public abstract class Jms {
 	 * @param connectionFactory the JMS ConnectionFactory to build on
 	 * @return the {@link JmsOutboundGatewaySpec} instance
 	 */
-	public static JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<DefaultMessageListenerContainer>
+	public static JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>
 	inboundGateway(ConnectionFactory connectionFactory) {
 		return inboundGateway(connectionFactory, DefaultMessageListenerContainer.class);
 	}
@@ -176,13 +176,14 @@ public abstract class Jms {
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
 	 * @return the {@link JmsOutboundGatewaySpec} instance
 	 */
-	public static <C extends AbstractMessageListenerContainer>
-	JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<C> inboundGateway(ConnectionFactory connectionFactory,
+	public static <S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+	JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<S, C> inboundGateway(ConnectionFactory connectionFactory,
 	                                                                               Class<C> containerClass) {
 		try {
-			JmsListenerContainerSpec<C> spec = new JmsListenerContainerSpec<C>(containerClass)
+			JmsListenerContainerSpec<S, C> spec =
+					new JmsListenerContainerSpec<S, C>(containerClass)
 					.connectionFactory(connectionFactory);
-			return new JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<C>(spec);
+			return new JmsInboundGatewaySpec.JmsInboundGatewayListenerContainerSpec<S, C>(spec);
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);
@@ -211,7 +212,7 @@ public abstract class Jms {
 	 */
 	@Deprecated
 	public static JmsMessageDrivenChannelAdapterSpec
-			.JmsMessageDrivenChannelAdapterListenerContainerSpec<DefaultMessageListenerContainer>
+			.JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>
 				messageDriverChannelAdapter(ConnectionFactory connectionFactory) {
 		return messageDrivenChannelAdapter(connectionFactory);
 	}
@@ -226,8 +227,8 @@ public abstract class Jms {
 	 * @deprecated - use {@link #messageDrivenChannelAdapter(ConnectionFactory, Class)}.
 	 */
 	@Deprecated
-	public static <C extends AbstractMessageListenerContainer>
-			JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<C>
+	public static <S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+			JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>
 				messageDriverChannelAdapter(ConnectionFactory connectionFactory, Class<C> containerClass) {
 		return messageDrivenChannelAdapter(connectionFactory, containerClass);
 	}
@@ -250,7 +251,7 @@ public abstract class Jms {
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */
 	public static JmsMessageDrivenChannelAdapterSpec
-			.JmsMessageDrivenChannelAdapterListenerContainerSpec<DefaultMessageListenerContainer>
+			.JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>
 				messageDrivenChannelAdapter(ConnectionFactory connectionFactory) {
 		return messageDrivenChannelAdapter(connectionFactory, DefaultMessageListenerContainer.class);
 	}
@@ -263,13 +264,14 @@ public abstract class Jms {
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */
-	public static <C extends AbstractMessageListenerContainer>
-	JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<C>
+	public static <S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+	JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>
 			messageDrivenChannelAdapter(ConnectionFactory connectionFactory, Class<C> containerClass) {
 		try {
-			JmsListenerContainerSpec<C> spec = new JmsListenerContainerSpec<C>(containerClass)
+			JmsListenerContainerSpec<S, C> spec =
+					new JmsListenerContainerSpec<S, C>(containerClass)
 					.connectionFactory(connectionFactory);
-			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<C>(spec);
+			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>(spec);
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);
@@ -283,10 +285,10 @@ public abstract class Jms {
 	 * @return the {@link JmsListenerContainerSpec} instance
 	 * @since 1.1
 	 */
-	public static JmsListenerContainerSpec<DefaultMessageListenerContainer> container(
-			ConnectionFactory connectionFactory, Destination destination) {
+	public static JmsDefaultListenerContainerSpec container(ConnectionFactory connectionFactory,
+			Destination destination) {
 		try {
-			return new JmsListenerContainerSpec<DefaultMessageListenerContainer>(DefaultMessageListenerContainer.class)
+			return new JmsDefaultListenerContainerSpec()
 					.connectionFactory(connectionFactory)
 					.destination(destination);
 		}
@@ -302,10 +304,10 @@ public abstract class Jms {
 	 * @return the {@link JmsListenerContainerSpec} instance
 	 * @since 1.1
 	 */
-	public static JmsListenerContainerSpec<DefaultMessageListenerContainer> container(
-			ConnectionFactory connectionFactory, String destinationName) {
+	public static JmsDefaultListenerContainerSpec container(ConnectionFactory connectionFactory,
+			String destinationName) {
 		try {
-			return new JmsListenerContainerSpec<DefaultMessageListenerContainer>(DefaultMessageListenerContainer.class)
+			return new JmsDefaultListenerContainerSpec()
 					.connectionFactory(connectionFactory)
 					.destination(destinationName);
 		}

--- a/src/main/java/org/springframework/integration/dsl/jms/JmsDefaultListenerContainerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/JmsDefaultListenerContainerSpec.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2016 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.jms;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.util.backoff.BackOff;
+
+/**
+ * A {@link DefaultMessageListenerContainer} specific {@link JmsListenerContainerSpec} extension.
+ *
+ * @author Artem Bilan
+ * @since 1.2
+ */
+public class JmsDefaultListenerContainerSpec
+		extends JmsListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer> {
+
+	JmsDefaultListenerContainerSpec() throws Exception {
+		super(DefaultMessageListenerContainer.class);
+	}
+
+	/**
+	 * Specify an {@link Executor}.
+	 * @param taskExecutor the {@link Executor} to use.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setTaskExecutor(Executor)
+	 */
+	public JmsDefaultListenerContainerSpec taskExecutor(Executor taskExecutor) {
+		this.target.setTaskExecutor(taskExecutor);
+		return this;
+	}
+
+	/**
+	 * Specify a {@link BackOff}.
+	 * @param backOff the {@link BackOff} to use.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setBackOff(BackOff)
+	 */
+	public JmsDefaultListenerContainerSpec backOff(BackOff backOff) {
+		this.target.setBackOff(backOff);
+		return this;
+	}
+
+	/**
+	 * Specify a recovery interval.
+	 * @param recoveryInterval the recovery interval to use.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setRecoveryInterval(long)
+	 */
+	public JmsDefaultListenerContainerSpec recoveryInterval(long recoveryInterval) {
+		this.target.setRecoveryInterval(recoveryInterval);
+		return this;
+	}
+
+	/**
+	 * Specify the level of caching that this listener container is allowed to apply,
+	 * in the form of the name of the corresponding constant: e.g. "CACHE_CONNECTION".
+	 * @param constantName the cache level constant name.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see #cacheLevel(int)
+	 * @see DefaultMessageListenerContainer#setCacheLevelName(String)
+	 */
+	public JmsDefaultListenerContainerSpec cacheLevelName(String constantName) {
+		this.target.setCacheLevelName(constantName);
+		return this;
+	}
+
+	/**
+	 * Specify the level of caching that this listener container is allowed to apply.
+	 * @param cacheLevel the level of caching.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setCacheLevel(int)
+	 */
+	public JmsDefaultListenerContainerSpec cacheLevel(int cacheLevel) {
+		this.target.setCacheLevel(cacheLevel);
+		return this;
+	}
+
+	/**
+	 * The concurrency to use.
+	 * @param concurrency the concurrency.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setConcurrency(String)
+	 */
+	public JmsDefaultListenerContainerSpec concurrency(String concurrency) {
+		this.target.setConcurrency(concurrency);
+		return this;
+	}
+
+	/**
+	 * The concurrent consumers number to use.
+	 * @param concurrentConsumers the concurrent consumers count.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setConcurrentConsumers(int)
+	 */
+	public JmsDefaultListenerContainerSpec concurrentConsumers(int concurrentConsumers) {
+		this.target.setConcurrentConsumers(concurrentConsumers);
+		return this;
+	}
+
+	/**
+	 * The max for concurrent consumers number to use.
+	 * @param maxConcurrentConsumers the max concurrent consumers count.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setMaxConcurrentConsumers(int)
+	 */
+	public JmsDefaultListenerContainerSpec maxConcurrentConsumers(int maxConcurrentConsumers) {
+		this.target.setMaxConcurrentConsumers(maxConcurrentConsumers);
+		return this;
+	}
+
+	/**
+	 * The max messages per task.
+	 * @param maxMessagesPerTask the max messages per task.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setMaxMessagesPerTask(int)
+	 */
+	public JmsDefaultListenerContainerSpec maxMessagesPerTask(int maxMessagesPerTask) {
+		this.target.setMaxMessagesPerTask(maxMessagesPerTask);
+		return this;
+	}
+
+	/**
+	 * The max for concurrent consumers number to use.
+	 * @param idleConsumerLimit the limit for idle consumer.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setMaxConcurrentConsumers(int)
+	 */
+	public JmsDefaultListenerContainerSpec idleConsumerLimit(int idleConsumerLimit) {
+		this.target.setIdleConsumerLimit(idleConsumerLimit);
+		return this;
+	}
+
+	/**
+	 * The the limit for idle task.
+	 * @param idleTaskExecutionLimit the limit for idle task.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setIdleTaskExecutionLimit(int)
+	 */
+	public JmsDefaultListenerContainerSpec idleTaskExecutionLimit(int idleTaskExecutionLimit) {
+		this.target.setIdleTaskExecutionLimit(idleTaskExecutionLimit);
+		return this;
+	}
+
+	/**
+	 * A {@link PlatformTransactionManager} reference.
+	 * @param transactionManager the {@link PlatformTransactionManager} to use.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setTransactionManager(PlatformTransactionManager)
+	 */
+	public JmsDefaultListenerContainerSpec transactionManager(PlatformTransactionManager transactionManager) {
+		this.target.setTransactionManager(transactionManager);
+		return this;
+	}
+
+	/**
+	 * A name for transaction.
+	 * @param transactionName the name for transaction.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setTransactionName(String)
+	 */
+	public JmsDefaultListenerContainerSpec transactionName(String transactionName) {
+		this.target.setTransactionName(transactionName);
+		return this;
+	}
+
+	/**
+	 * A transaction timeout.
+	 * @param transactionTimeout the transaction timeout.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setTransactionTimeout(int)
+	 */
+	public JmsDefaultListenerContainerSpec transactionTimeout(int transactionTimeout) {
+		this.target.setTransactionTimeout(transactionTimeout);
+		return this;
+	}
+
+	/**
+	 * A receive timeout.
+	 * @param receiveTimeout the receive timeout.
+	 * @return current {@link JmsDefaultListenerContainerSpec}.
+	 * @see DefaultMessageListenerContainer#setReceiveTimeout(long)
+	 */
+	public JmsDefaultListenerContainerSpec receiveTimeout(long receiveTimeout) {
+		this.target.setReceiveTimeout(receiveTimeout);
+		return this;
+	}
+
+}

--- a/src/main/java/org/springframework/integration/dsl/jms/JmsInboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/JmsInboundGatewaySpec.java
@@ -170,12 +170,12 @@ public class JmsInboundGatewaySpec<S extends JmsInboundGatewaySpec<S>>
 		return _this();
 	}
 
-	public static class JmsInboundGatewayListenerContainerSpec<C extends AbstractMessageListenerContainer>
-			extends JmsInboundGatewaySpec<JmsInboundGatewayListenerContainerSpec<C>> {
+	public static class JmsInboundGatewayListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+			extends JmsInboundGatewaySpec<JmsInboundGatewayListenerContainerSpec<S, C>> {
 
-		private final JmsListenerContainerSpec<C> spec;
+		private final JmsListenerContainerSpec<S, C> spec;
 
-		JmsInboundGatewayListenerContainerSpec(JmsListenerContainerSpec<C> spec) {
+		JmsInboundGatewayListenerContainerSpec(JmsListenerContainerSpec<S, C> spec) {
 			super(spec.get());
 			this.spec = spec;
 			this.spec.get().setAutoStartup(false);
@@ -186,7 +186,7 @@ public class JmsInboundGatewaySpec<S extends JmsInboundGatewaySpec<S>>
 		 * @return the spec.
 		 * @see JmsListenerContainerSpec#destination(Destination)
 		 */
-		public JmsInboundGatewayListenerContainerSpec<C> destination(Destination destination) {
+		public JmsInboundGatewayListenerContainerSpec<S, C> destination(Destination destination) {
 			spec.destination(destination);
 			return _this();
 		}
@@ -196,13 +196,13 @@ public class JmsInboundGatewaySpec<S extends JmsInboundGatewaySpec<S>>
 		 * @return the spec.
 		 * @see JmsListenerContainerSpec#destination(String)
 		 */
-		public JmsInboundGatewayListenerContainerSpec<C> destination(String destinationName) {
+		public JmsInboundGatewayListenerContainerSpec<S, C> destination(String destinationName) {
 			spec.destination(destinationName);
 			return _this();
 		}
 
-		public JmsInboundGatewayListenerContainerSpec<C> configureListenerContainer(
-				Consumer<JmsListenerContainerSpec<C>> configurer) {
+		public JmsInboundGatewayListenerContainerSpec<S, C> configureListenerContainer(
+				Consumer<JmsListenerContainerSpec<S, C>> configurer) {
 			Assert.notNull(configurer);
 			configurer.accept(this.spec);
 			return _this();

--- a/src/main/java/org/springframework/integration/dsl/jms/JmsListenerContainerSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/JmsListenerContainerSpec.java
@@ -29,13 +29,13 @@ import org.springframework.util.ErrorHandler;
  * @author Artem Bilan
  * @author Gary Russell
  */
-public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer>
-		extends JmsDestinationAccessorSpec<JmsListenerContainerSpec<C>, C> {
+public class JmsListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+		extends JmsDestinationAccessorSpec<S, C> {
 
 	JmsListenerContainerSpec(Class<C> aClass) throws Exception {
 		super(aClass.newInstance());
 		if (DefaultMessageListenerContainer.class.isAssignableFrom(aClass)) {
-			target.setSessionTransacted(true);
+			this.target.setSessionTransacted(true);
 		}
 	}
 
@@ -44,8 +44,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setDestination(Destination)
 	 */
-	JmsListenerContainerSpec<C> destination(Destination destination) {
-		target.setDestination(destination);
+	S destination(Destination destination) {
+		this.target.setDestination(destination);
 		return _this();
 	}
 
@@ -54,8 +54,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setDestinationName(String)
 	 */
-	JmsListenerContainerSpec<C> destination(String destinationName) {
-		target.setDestinationName(destinationName);
+	S destination(String destinationName) {
+		this.target.setDestinationName(destinationName);
 		return _this();
 	}
 
@@ -64,8 +64,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setMessageSelector(String)
 	 */
-	public JmsListenerContainerSpec<C> messageSelector(String messageSelector) {
-		target.setMessageSelector(messageSelector);
+	public S messageSelector(String messageSelector) {
+		this.target.setMessageSelector(messageSelector);
 		return _this();
 	}
 
@@ -74,8 +74,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setSubscriptionDurable(boolean)
 	 */
-	public JmsListenerContainerSpec<C> subscriptionDurable(boolean subscriptionDurable) {
-		target.setSubscriptionDurable(subscriptionDurable);
+	public S subscriptionDurable(boolean subscriptionDurable) {
+		this.target.setSubscriptionDurable(subscriptionDurable);
 		return _this();
 	}
 
@@ -84,8 +84,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setDurableSubscriptionName(String)
 	 */
-	public JmsListenerContainerSpec<C> durableSubscriptionName(String durableSubscriptionName) {
-		target.setDurableSubscriptionName(durableSubscriptionName);
+	public S durableSubscriptionName(String durableSubscriptionName) {
+		this.target.setDurableSubscriptionName(durableSubscriptionName);
 		return _this();
 	}
 
@@ -94,8 +94,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setExceptionListener(ExceptionListener)
 	 */
-	public JmsListenerContainerSpec<C> exceptionListener(ExceptionListener exceptionListener) {
-		target.setExceptionListener(exceptionListener);
+	public S exceptionListener(ExceptionListener exceptionListener) {
+		this.target.setExceptionListener(exceptionListener);
 		return _this();
 	}
 
@@ -104,8 +104,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setErrorHandler(ErrorHandler)
 	 */
-	public JmsListenerContainerSpec<C> errorHandler(ErrorHandler errorHandler) {
-		target.setErrorHandler(errorHandler);
+	public S errorHandler(ErrorHandler errorHandler) {
+		this.target.setErrorHandler(errorHandler);
 		return _this();
 	}
 
@@ -114,8 +114,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setExposeListenerSession(boolean)
 	 */
-	public JmsListenerContainerSpec<C> exposeListenerSession(boolean exposeListenerSession) {
-		target.setExposeListenerSession(exposeListenerSession);
+	public S exposeListenerSession(boolean exposeListenerSession) {
+		this.target.setExposeListenerSession(exposeListenerSession);
 		return _this();
 	}
 
@@ -124,8 +124,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setAcceptMessagesWhileStopping(boolean)
 	 */
-	public JmsListenerContainerSpec<C> acceptMessagesWhileStopping(boolean acceptMessagesWhileStopping) {
-		target.setAcceptMessagesWhileStopping(acceptMessagesWhileStopping);
+	public S acceptMessagesWhileStopping(boolean acceptMessagesWhileStopping) {
+		this.target.setAcceptMessagesWhileStopping(acceptMessagesWhileStopping);
 		return _this();
 	}
 
@@ -134,8 +134,8 @@ public class JmsListenerContainerSpec<C extends AbstractMessageListenerContainer
 	 * @return the spec.
 	 * @see AbstractMessageListenerContainer#setClientId(String)
 	 */
-	public JmsListenerContainerSpec<C> clientId(String clientId) {
-		target.setClientId(clientId);
+	public S clientId(String clientId) {
+		this.target.setClientId(clientId);
 		return _this();
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/jms/JmsMessageDrivenChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/JmsMessageDrivenChannelAdapterSpec.java
@@ -71,12 +71,12 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 
 
 	public static class
-			JmsMessageDrivenChannelAdapterListenerContainerSpec<C extends AbstractMessageListenerContainer> extends
-			JmsMessageDrivenChannelAdapterSpec<JmsMessageDrivenChannelAdapterListenerContainerSpec<C>> {
+			JmsMessageDrivenChannelAdapterListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+			extends JmsMessageDrivenChannelAdapterSpec<JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>> {
 
-		private final JmsListenerContainerSpec<C> spec;
+		private final JmsListenerContainerSpec<S, C> spec;
 
-		JmsMessageDrivenChannelAdapterListenerContainerSpec(JmsListenerContainerSpec<C> spec) {
+		JmsMessageDrivenChannelAdapterListenerContainerSpec(JmsListenerContainerSpec<S, C> spec) {
 			super(spec.get());
 			this.spec = spec;
 			this.spec.get().setAutoStartup(false);
@@ -87,7 +87,7 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 		 * @return the spec.
 		 * @see JmsListenerContainerSpec#destination(Destination)
 		 */
-		public JmsMessageDrivenChannelAdapterListenerContainerSpec<C> destination(Destination destination) {
+		public JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C> destination(Destination destination) {
 			spec.destination(destination);
 			return _this();
 		}
@@ -97,7 +97,7 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 		 * @return the spec.
 		 * @see JmsListenerContainerSpec#destination(String)
 		 */
-		public JmsMessageDrivenChannelAdapterListenerContainerSpec<C> destination(String destinationName) {
+		public JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C> destination(String destinationName) {
 			spec.destination(destinationName);
 			return _this();
 		}
@@ -108,8 +108,8 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 		 * @param configurer the configurer.
 		 * @return the spec.
 		 */
-		public JmsMessageDrivenChannelAdapterListenerContainerSpec<C> configureListenerContainer(
-				Consumer<JmsListenerContainerSpec<C>> configurer) {
+		public JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C> configureListenerContainer(
+				Consumer<JmsListenerContainerSpec<S, C>> configurer) {
 			Assert.notNull(configurer);
 			configurer.accept(this.spec);
 			return _this();

--- a/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/jms/JmsTests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -337,6 +338,7 @@ public class JmsTests {
 					.from(Jms.messageDrivenChannelAdapter(
 							Jms.container(this.jmsConnectionFactory, "containerSpecDestination")
 									.pubSubDomain(false)
+									.taskExecutor(Executors.newCachedThreadPool())
 									.get()))
 					.transform(String::trim)
 					.channel(jmsOutboundInboundReplyChannel())


### PR DESCRIPTION
Fixes GH-95 (https://github.com/spring-projects/spring-integration-java-dsl/issues/95)

For better fluent API in the `configureListenerContainer()` callback introduce `JmsDefaultListenerContainerSpec` for the `DefaultMessageListenerContainer`