### PR TITLE
GH-74: Allow `generics` for router's recipients

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -2098,10 +2098,11 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * with provided options from {@link RouterSpec}.
 	 * @param expression the expression to use.
 	 * @param routerConfigurer the {@link Consumer} to provide {@link ExpressionEvaluatingRouter} options.
+	 * @param <T> the target result type.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
-	public B route(String expression, Consumer<RouterSpec<Object, ExpressionEvaluatingRouter>> routerConfigurer) {
-		return this.route(expression, routerConfigurer, null);
+	public <T> B route(String expression, Consumer<RouterSpec<T, ExpressionEvaluatingRouter>> routerConfigurer) {
+		return route(expression, routerConfigurer, null);
 	}
 
 	/**
@@ -2111,9 +2112,10 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @param expression the expression to use.
 	 * @param routerConfigurer the {@link Consumer} to provide {@link ExpressionEvaluatingRouter} options.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
+	 * @param <T> the target result type.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
-	public B route(String expression, Consumer<RouterSpec<Object, ExpressionEvaluatingRouter>> routerConfigurer,
+	public <T> B route(String expression, Consumer<RouterSpec<T, ExpressionEvaluatingRouter>> routerConfigurer,
 			Consumer<GenericEndpointSpec<ExpressionEvaluatingRouter>> endpointConfigurer) {
 		return this.route(new ExpressionEvaluatingRouter(PARSER.parseExpression(expression)), routerConfigurer,
 				endpointConfigurer);

--- a/src/main/java/org/springframework/integration/dsl/LambdaMessageProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/LambdaMessageProcessor.java
@@ -78,7 +78,7 @@ class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFactoryAwa
 		this.method = methodValue.get();
 		this.method.setAccessible(true);
 		this.parameterTypes = this.method.getParameterTypes();
-		this.payloadType = TypeDescriptor.valueOf(payloadType);
+		this.payloadType = payloadType != null ? TypeDescriptor.valueOf(payloadType) : null;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -16,11 +16,15 @@
 
 package org.springframework.integration.dsl;
 
+import org.springframework.expression.Expression;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.core.GenericSelector;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.router.RecipientListRouter;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * An {@link AbstractRouterSpec} for a {@link RecipientListRouter}.
@@ -39,9 +43,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @return the router spec.
 	 */
 	public RecipientListRouterSpec recipient(String channelName) {
-		Assert.hasText(channelName);
-		((DslRecipientListRouter) this.target).add(channelName, (MessageSelector) null);
-		return _this();
+		return recipient(channelName, (String) null);
 	}
 
 	/**
@@ -51,9 +53,33 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @return the router spec.
 	 */
 	public RecipientListRouterSpec recipient(String channelName, String expression) {
+		return recipient(channelName, StringUtils.hasText(expression) ? PARSER.parseExpression(expression): null);
+	}
+
+	/**
+	 * Adds a recipient channel that will be selected if the the expression evaluates to 'true'.
+	 * @param channelName the channel name.
+	 * @param expression the expression.
+	 * @return the router spec.
+	 * @since 1.2
+	 */
+	public RecipientListRouterSpec recipient(String channelName, Expression expression) {
 		Assert.hasText(channelName);
 		((DslRecipientListRouter) this.target).add(channelName, expression);
 		return _this();
+	}
+
+
+	/**
+	 * Adds a recipient channel that will be selected if the the selector's accept method returns 'true'.
+	 * @param channelName the channel name.
+	 * @param selector the selector.
+	 * @return the router spec.
+	 * @deprecated since 1.2 in favor of {@link #recipient(String, GenericSelector)}
+	 */
+	@Deprecated
+	public RecipientListRouterSpec recipient(String channelName, MessageSelector selector) {
+		return recipient(channelName, (GenericSelector<Message<?>>) selector);
 	}
 
 	/**
@@ -61,8 +87,9 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param channelName the channel name.
 	 * @param selector the selector.
 	 * @return the router spec.
+	 * @since 1.2
 	 */
-	public RecipientListRouterSpec recipient(String channelName, MessageSelector selector) {
+	public <P> RecipientListRouterSpec recipient(String channelName, GenericSelector<P> selector) {
 		Assert.hasText(channelName);
 		((DslRecipientListRouter) this.target).add(channelName, selector);
 		return _this();
@@ -74,9 +101,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @return the router spec.
 	 */
 	public RecipientListRouterSpec recipient(MessageChannel channel) {
-		Assert.notNull(channel);
-		((DslRecipientListRouter) this.target).add(channel, (MessageSelector) null);
-		return _this();
+		return recipient(channel, (String) null);
 	}
 
 	/**
@@ -86,6 +111,17 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @return the router spec.
 	 */
 	public RecipientListRouterSpec recipient(MessageChannel channel, String expression) {
+		return recipient(channel, StringUtils.hasText(expression) ? PARSER.parseExpression(expression): null);
+	}
+
+	/**
+	 * Adds a recipient channel that will be selected if the the expression evaluates to 'true'.
+	 * @param channel the recipient channel.
+	 * @param expression the expression.
+	 * @return the router spec.
+	 * @since 1.2
+	 */
+	public RecipientListRouterSpec recipient(MessageChannel channel, Expression expression) {
 		Assert.notNull(channel);
 		((DslRecipientListRouter) this.target).add(channel, expression);
 		return _this();
@@ -96,8 +132,20 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param channel the recipient channel.
 	 * @param selector the selector.
 	 * @return the router spec.
+	 * @deprecated since 1.2 in favor of {@link #recipient(MessageChannel, GenericSelector)}
 	 */
+	@Deprecated
 	public RecipientListRouterSpec recipient(MessageChannel channel, MessageSelector selector) {
+		return recipient(channel, (GenericSelector<Message<?>>) selector);
+	}
+
+	/**
+	 * Adds a recipient channel that will be selected if the the selector's accept method returns 'true'.
+	 * @param channel the recipient channel.
+	 * @param selector the selector.
+	 * @return the router spec.
+	 */
+	public <P> RecipientListRouterSpec recipient(MessageChannel channel, GenericSelector<P> selector) {
 		Assert.notNull(channel);
 		((DslRecipientListRouter) this.target).add(channel, selector);
 		return _this();
@@ -108,13 +156,36 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param selector the selector.
 	 * @param subFlow the subflow.
 	 * @return the router spec.
+	 * @deprecated since 1.2 in favor of {@link #recipientFlow(GenericSelector selector, IntegrationFlow subFlow)}
 	 */
+	@Deprecated
 	public RecipientListRouterSpec recipientFlow(MessageSelector selector, IntegrationFlow subFlow) {
+		return recipientFlow((GenericSelector<Message<?>>) selector, subFlow);
+	}
+
+	/**
+	 * Adds a subflow that will be invoked if the selector's accept methods returns 'true'.
+	 * @param selector the selector.
+	 * @param subFlow the subflow.
+	 * @return the router spec.
+	 */
+	public <P> RecipientListRouterSpec recipientFlow(GenericSelector<P> selector, IntegrationFlow subFlow) {
 		Assert.notNull(subFlow);
 		DirectChannel channel = populateSubFlow(subFlow);
 		((DslRecipientListRouter) this.target).add(channel, selector);
 		return _this();
 	}
+
+	/**
+	 * Adds a subflow that will be invoked as a recipient.
+	 * @param subFlow the subflow.
+	 * @return the router spec.
+	 * @since 1.2
+	 */
+	public RecipientListRouterSpec recipientFlow(IntegrationFlow subFlow) {
+		return recipientFlow((String) null, subFlow);
+	}
+
 
 	/**
 	 * Adds a subflow that will be invoked if the expression evaluates to 'true'.
@@ -123,6 +194,17 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @return the router spec.
 	 */
 	public RecipientListRouterSpec recipientFlow(String expression, IntegrationFlow subFlow) {
+		return recipientFlow(StringUtils.hasText(expression) ? PARSER.parseExpression(expression): null, subFlow);
+	}
+
+	/**
+	 * Adds a subflow that will be invoked if the expression evaluates to 'true'.
+	 * @param expression the expression.
+	 * @param subFlow the subflow.
+	 * @return the router spec.
+	 * @since 1.2
+	 */
+	public RecipientListRouterSpec recipientFlow(Expression expression, IntegrationFlow subFlow) {
 		Assert.notNull(subFlow);
 		DirectChannel channel = populateSubFlow(subFlow);
 		((DslRecipientListRouter) this.target).add(channel, expression);

--- a/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -84,6 +84,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * Adds a recipient channel that will be selected if the the selector's accept method returns 'true'.
 	 * @param channelName the channel name.
 	 * @param selector the selector.
+	 * @param <P> the selector source type.
 	 * @return the router spec.
 	 * @since 1.2
 	 */
@@ -139,6 +140,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * Adds a recipient channel that will be selected if the the selector's accept method returns 'true'.
 	 * @param channel the recipient channel.
 	 * @param selector the selector.
+	 * @param <P> the selector source type.
 	 * @return the router spec.
 	 */
 	public <P> RecipientListRouterSpec recipient(MessageChannel channel, GenericSelector<P> selector) {
@@ -161,6 +163,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * Adds a subflow that will be invoked if the selector's accept methods returns 'true'.
 	 * @param selector the selector.
 	 * @param subFlow the subflow.
+	 * @param <P> the selector source type.
 	 * @return the router spec.
 	 */
 	public <P> RecipientListRouterSpec recipientFlow(GenericSelector<P> selector, IntegrationFlow subFlow) {

--- a/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -142,6 +142,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param selector the selector.
 	 * @param <P> the selector source type.
 	 * @return the router spec.
+	 * @since 1.2
 	 */
 	public <P> RecipientListRouterSpec recipient(MessageChannel channel, GenericSelector<P> selector) {
 		Assert.notNull(channel);
@@ -165,6 +166,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param subFlow the subflow.
 	 * @param <P> the selector source type.
 	 * @return the router spec.
+	 * @since 1.2
 	 */
 	public <P> RecipientListRouterSpec recipientFlow(GenericSelector<P> selector, IntegrationFlow subFlow) {
 		Assert.notNull(subFlow);

--- a/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -75,9 +75,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param channelName the channel name.
 	 * @param selector the selector.
 	 * @return the router spec.
-	 * @deprecated since 1.2 in favor of {@link #recipient(String, GenericSelector)}
 	 */
-	@Deprecated
 	public RecipientListRouterSpec recipient(String channelName, MessageSelector selector) {
 		return recipient(channelName, (GenericSelector<Message<?>>) selector);
 	}
@@ -132,9 +130,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param channel the recipient channel.
 	 * @param selector the selector.
 	 * @return the router spec.
-	 * @deprecated since 1.2 in favor of {@link #recipient(MessageChannel, GenericSelector)}
 	 */
-	@Deprecated
 	public RecipientListRouterSpec recipient(MessageChannel channel, MessageSelector selector) {
 		return recipient(channel, (GenericSelector<Message<?>>) selector);
 	}
@@ -156,9 +152,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param selector the selector.
 	 * @param subFlow the subflow.
 	 * @return the router spec.
-	 * @deprecated since 1.2 in favor of {@link #recipientFlow(GenericSelector selector, IntegrationFlow subFlow)}
 	 */
-	@Deprecated
 	public RecipientListRouterSpec recipientFlow(MessageSelector selector, IntegrationFlow subFlow) {
 		return recipientFlow((GenericSelector<Message<?>>) selector, subFlow);
 	}

--- a/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -124,7 +124,7 @@ public final class RouterSpec<K, R extends AbstractMappingMessageRouter> extends
 	 * @param subFlow the subFlow.
 	 * @return the router spec.
 	 */
-	public RouterSpec<K, R> subFlowMapping(Object key, IntegrationFlow subFlow) {
+	public RouterSpec<K, R> subFlowMapping(K key, IntegrationFlow subFlow) {
 		Assert.notNull(key);
 		Assert.notNull(subFlow);
 		Assert.state(!(StringUtils.hasText(this.prefix) || StringUtils.hasText(this.suffix)),

--- a/src/main/java/org/springframework/integration/dsl/jms/Jms.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/Jms.java
@@ -175,6 +175,7 @@ public abstract class Jms {
 	 *                          to instantiate listener container
 	 * @param <S>               the {@link JmsListenerContainerSpec} inheritor type
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
+	 * @param <S>               the {@link JmsMessageDrivenChannelAdapterSpec} inheritor type
 	 * @return the {@link JmsOutboundGatewaySpec} instance
 	 */
 	public static <S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
@@ -225,6 +226,7 @@ public abstract class Jms {
 	 *                          to instantiate listener container
 	 * @param <S>               the {@link JmsListenerContainerSpec} inheritor type
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
+	 * @param <S>               the {@link JmsMessageDrivenChannelAdapterSpec} inheritor type
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 * @deprecated - use {@link #messageDrivenChannelAdapter(ConnectionFactory, Class)}.
 	 */
@@ -265,6 +267,7 @@ public abstract class Jms {
 	 *                          to instantiate listener container
 	 * @param <S>               the {@link JmsListenerContainerSpec} inheritor type
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
+	 * @param <S>               the {@link JmsMessageDrivenChannelAdapterSpec} inheritor type
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */
 	public static <S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>

--- a/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
@@ -513,7 +513,7 @@ public class RouterTests {
 		@Bean
 		public IntegrationFlow routeSubflowToReplyChannelFlow() {
 			return f -> f
-					.route("true", m -> m
+					.<Boolean>route("true", m -> m
 							.subFlowMapping(true, sf -> sf
 													.<String>handle((p, h) -> p.toUpperCase())
 									)

--- a/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
@@ -41,8 +41,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.config.EnableMessageHistory;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.support.FunctionExpression;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -573,7 +575,8 @@ public class RouterTests {
 									f -> f.transform("Hello "::concat)
 											.channel(c -> c.queue("recipientListSubFlow2Result")))
 							.recipientFlow(new FunctionExpression<Message<?>>(m -> "bax".equals(m.getPayload())),
-									f -> f.channel(c -> c.queue("recipientListSubFlow3Result"))))
+									f -> f.channel(c -> c.queue("recipientListSubFlow3Result")))
+							.defaultOutputToParentFlow())
 					.channel("defaultOutputChannel")
 					.get();
 		}

--- a/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
@@ -41,7 +41,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
-import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.support.FunctionExpression;
@@ -514,7 +513,7 @@ public class RouterTests {
 		@Bean
 		public IntegrationFlow routeSubflowToReplyChannelFlow() {
 			return f -> f
-					.<Integer, Boolean>route("true", m -> m
+					.route("true", m -> m
 							.subFlowMapping(true, sf -> sf
 													.<String>handle((p, h) -> p.toUpperCase())
 									)
@@ -559,7 +558,6 @@ public class RouterTests {
 		}
 
 		@Bean
-		@SuppressWarnings("deprecation")
 		public IntegrationFlow recipientListFlow() {
 			return IntegrationFlows.from("recipientListInput")
 					.<String, String>transform(p -> p.replaceFirst("Payload", ""))
@@ -704,6 +702,7 @@ public class RouterTests {
 			return name + "-channel";
 		}
 
+		@SuppressWarnings("unused")
 		public String routeMessage(Message<?> message) {
 			if (message.getPayload().equals("foo")) {
 				return "foo-channel";

--- a/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
@@ -565,13 +565,13 @@ public class RouterTests {
 					.<String, String>transform(p -> p.replaceFirst("Payload", ""))
 					.routeToRecipients(r -> r
 							.recipient("foo-channel", "'foo' == payload")
-							.recipient("bar-channel", (MessageSelector) m ->
+							.recipient("bar-channel", m ->
 									m.getHeaders().containsKey("recipient")
 											&& (boolean) m.getHeaders().get("recipient"))
 							.recipientFlow("'foo' == payload or 'bar' == payload or 'baz' == payload",
 									f -> f.<String, String>transform(String::toUpperCase)
 											.channel(c -> c.queue("recipientListSubFlow1Result")))
-							.recipientFlow((String p) -> "baz".equals(p),
+							.recipientFlow((String p) -> p.startsWith("baz"),
 									f -> f.transform("Hello "::concat)
 											.channel(c -> c.queue("recipientListSubFlow2Result")))
 							.recipientFlow(new FunctionExpression<Message<?>>(m -> "bax".equals(m.getPayload())),


### PR DESCRIPTION
Fixes: GH-74 (https://github.com/spring-projects/spring-integration-java-dsl/issues/74)

* Introduce a bunch of `GenericSelector<P>` method into `RecipientListRouterSpec` to let to have type safe target code.
* Deprecate `MessageSelector` variants since they can be simply covered with the Lambda casting `.recipient("foo", (MessageSelector) m ->`
* Also add `Expression` variant `recipient(Flow)` methods to let to provide any custom `Expression`
* Confirm with test modification that all changes have been met