### PR TITLE
GH-75: Add `Scatter-Gather` support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
 	reactorVersion = '2.0.8.RELEASE'
 	scalaVersion = '2.10'
 	slf4jVersion = '1.7.21'
-	springIntegrationVersion = project.hasProperty('siVersion') ? project.siVersion : '4.3.1.BUILD-SNAPSHOT'
+	springIntegrationVersion = project.hasProperty('siVersion') ? project.siVersion : '4.3.1.RELEASE'
 	springIntegrationKafkaVersion = '1.3.1.RELEASE'
 	springKafkaVersion = '1.0.2.RELEASE'
 	springBootVersion = '1.4.0.BUILD-SNAPSHOT'

--- a/src/main/java/org/springframework/integration/dsl/ScatterGatherSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/ScatterGatherSpec.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl;
+
+import org.springframework.integration.dsl.core.ConsumerEndpointSpec;
+import org.springframework.integration.scattergather.ScatterGatherHandler;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * A {@link GenericEndpointSpec} extension for the {@link ScatterGatherHandler}.
+ *
+ * @author Artem Bilan
+ * @since 1.2
+ * @see ScatterGatherHandler
+ */
+public class ScatterGatherSpec extends ConsumerEndpointSpec<ScatterGatherSpec, ScatterGatherHandler> {
+
+	ScatterGatherSpec(ScatterGatherHandler messageHandler) {
+		super(messageHandler);
+	}
+
+	/**
+	 * Specify a {@link MessageChannel} (optional) which is used internally
+	 * in the {@link ScatterGatherHandler} for gathering (aggregate) results for scattered requests.
+	 * @param gatherChannel the {@link MessageChannel} for gathering results.
+	 * @return the current {@link ScatterGatherSpec} instance.
+	 */
+	public ScatterGatherSpec gatherChannel(MessageChannel gatherChannel) {
+		this.target.getT2().setGatherChannel(gatherChannel);
+		return this;
+	}
+
+	/**
+	 * Specify a timeout (in milliseconds) for the
+	 * {@link org.springframework.messaging.PollableChannel#receive(long)} operation
+	 * to wait for gathering results to output.
+	 * Defaults to {@code -1} - to wait indefinitely.
+	 * @param gatherTimeout the {@link org.springframework.messaging.PollableChannel} receive timeout.
+	 * @return the current {@link ScatterGatherSpec} instance.
+	 */
+	public ScatterGatherSpec gatherTimeout(long gatherTimeout) {
+		this.target.getT2().setGatherTimeout(gatherTimeout);
+		return this;
+	}
+
+}

--- a/src/main/java/org/springframework/integration/dsl/jms/Jms.java
+++ b/src/main/java/org/springframework/integration/dsl/jms/Jms.java
@@ -173,6 +173,7 @@ public abstract class Jms {
 	 * @param connectionFactory the JMS ConnectionFactory to build on
 	 * @param containerClass    the {@link AbstractMessageListenerContainer} implementation class
 	 *                          to instantiate listener container
+	 * @param <S>               the {@link JmsListenerContainerSpec} inheritor type
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
 	 * @return the {@link JmsOutboundGatewaySpec} instance
 	 */
@@ -222,6 +223,7 @@ public abstract class Jms {
 	 * @param connectionFactory the JMS ConnectionFactory to build on
 	 * @param containerClass    the {@link AbstractMessageListenerContainer} implementation class
 	 *                          to instantiate listener container
+	 * @param <S>               the {@link JmsListenerContainerSpec} inheritor type
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 * @deprecated - use {@link #messageDrivenChannelAdapter(ConnectionFactory, Class)}.
@@ -261,6 +263,7 @@ public abstract class Jms {
 	 * @param connectionFactory the JMS ConnectionFactory to build on
 	 * @param containerClass    the {@link AbstractMessageListenerContainer} implementation class
 	 *                          to instantiate listener container
+	 * @param <S>               the {@link JmsListenerContainerSpec} inheritor type
 	 * @param <C>               the {@link AbstractMessageListenerContainer} inheritor type
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */


### PR DESCRIPTION
Fixes GH-75 (https://github.com/spring-projects/spring-integration-java-dsl/issues/75)

* Add `.scatterGather()` EIP-method
* Add `distribution` test-case for `.scatterGather()`
* Upgrade to SI-4.3.1 and address TODO in the `RouterTests`
* Fix JavaDocs warning in the `Jms`