### PR TITLE
GH-77: Router's default output improvements

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/AbstractRouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/AbstractRouterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,27 @@
 
 package org.springframework.integration.dsl;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.dsl.core.ComponentsRegistration;
 import org.springframework.integration.dsl.core.MessageHandlerSpec;
 import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.util.Assert;
 
 /**
  * A {@link MessageHandlerSpec} for {@link AbstractMessageRouter}s.
  * @author Artem Bilan
  */
 public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends AbstractMessageRouter>
-		extends MessageHandlerSpec<S, R> {
+		extends MessageHandlerSpec<S, R> implements ComponentsRegistration {
+
+	protected final List<Object> subFlows = new ArrayList<Object>();
+
+	private boolean defaultToParentFlow;
 
 	AbstractRouterSpec(R router) {
 		this.target = router;
@@ -49,6 +61,69 @@ public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends Ab
 		this.target.setApplySequence(applySequence);
 		return _this();
 	}
+
+	/**
+	 * Specify a {@link MessageChannel} bean name as a default output from the router.
+	 * @param channelName the {@link MessageChannel} bean name.
+	 * @return the router spec.
+	 * @since 1.2
+	 * @see AbstractMessageRouter#setDefaultOutputChannelName(String)
+	 */
+	public S defaultOutputChannel(String channelName) {
+		this.target.setDefaultOutputChannelName(channelName);
+		return _this();
+	}
+
+	/**
+	 * Specify a {@link MessageChannel} as a default output from the router.
+	 * @param channel the {@link MessageChannel} to use.
+	 * @return the router spec.
+	 * @since 1.2
+	 * @see AbstractMessageRouter#setDefaultOutputChannel(MessageChannel)
+	 */
+	public S defaultOutputChannel(MessageChannel channel) {
+		this.target.setDefaultOutputChannel(channel);
+		return _this();
+	}
+
+	/**
+	 * Specify an {@link IntegrationFlow} as an output from the router when no any other mapping has matched.
+	 * @param subFlow the {@link IntegrationFlow} for default mapping.
+	 * @return the router spec.
+	 * @since 1.2
+	 */
+	public S defaultSubFlowMapping(IntegrationFlow subFlow) {
+		Assert.notNull(subFlow);
+		DirectChannel channel = new DirectChannel();
+		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(channel);
+		subFlow.configure(flowBuilder);
+
+		this.subFlows.add(flowBuilder);
+
+		return defaultOutputChannel(channel);
+	}
+
+	/**
+	 * Make a default output mapping of the router to the parent flow.
+	 * Use the next, after router, parent flow {@link MessageChannel} as a
+	 * {@link AbstractMessageRouter#setDefaultOutputChannel(MessageChannel)} of this router.
+	 * @return the router spec.
+	 * @since 1.2
+	 */
+	public S defaultOutputToParentFlow() {
+		this.defaultToParentFlow = true;
+		return _this();
+	}
+
+	boolean isDefaultToParentFlow() {
+		return this.defaultToParentFlow;
+	}
+
+	@Override
+	public Collection<Object> getComponentsToRegister() {
+		return this.subFlows;
+	}
+
 
 	@Override
 	protected R doGet() {

--- a/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,8 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageSelector;
-import org.springframework.integration.dsl.core.ComponentsRegistration;
 import org.springframework.integration.router.RecipientListRouter;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
@@ -32,10 +27,7 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  */
-public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRouterSpec, RecipientListRouter>
-		implements ComponentsRegistration {
-
-	private final List<Object> subFlows = new ArrayList<Object>();
+public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRouterSpec, RecipientListRouter> {
 
 	RecipientListRouterSpec() {
 		super(new DslRecipientListRouter());
@@ -143,11 +135,6 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 		subFlow.configure(flowBuilder);
 		this.subFlows.add(flowBuilder.get());
 		return channel;
-	}
-
-	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return subFlows;
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -16,10 +16,8 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.convert.ConversionService;
@@ -40,8 +38,6 @@ import org.springframework.util.StringUtils;
  */
 public final class RouterSpec<K, R extends AbstractMappingMessageRouter> extends AbstractRouterSpec<RouterSpec<K, R>, R>
 		implements ComponentsRegistration {
-
-	private final List<Object> subFlows = new ArrayList<Object>();
 
 	private final RouterMappingProvider mappingProvider;
 
@@ -146,8 +142,10 @@ public final class RouterSpec<K, R extends AbstractMappingMessageRouter> extends
 
 	@Override
 	public Collection<Object> getComponentsToRegister() {
+		// The 'mappingProvider' must be added to the 'componentToRegister' in the end to
+		// let all other components to be registered before the 'RouterMappingProvider.onInit()' logic.
 		this.subFlows.add(this.mappingProvider);
-		return this.subFlows;
+		return super.getComponentsToRegister();
 	}
 
 	private static class RouterMappingProvider extends IntegrationObjectSupport {

--- a/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
@@ -215,6 +215,7 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 	}
 
 	private void processIntegrationComponentSpec(IntegrationComponentSpec<?, ?> bean) {
+		registerComponent(bean.get(), generateBeanName(bean.get()), null, false);
 		if (bean instanceof ComponentsRegistration) {
 			Collection<Object> componentsToRegister = ((ComponentsRegistration) bean).getComponentsToRegister();
 			for (Object component : componentsToRegister) {

--- a/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/routers/RouterTests.java
@@ -658,8 +658,6 @@ public class RouterTests {
 			return new QueueChannel();
 		}
 
-	}
-
 		@Bean
 		public IntegrationFlow scatterGatherFlow() {
 			return f -> f
@@ -677,6 +675,8 @@ public class RouterTests {
 							scatterGather -> scatterGather
 									.gatherTimeout(10_000));
 		}
+
+	}
 
 	private static class RoutingTestBean {
 

--- a/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/sftp/SftpTests.java
@@ -242,7 +242,6 @@ public class SftpTests {
 		@Bean
 		public IntegrationFlow sftpOutboundFlow() {
 			return IntegrationFlows.from("toSftpChannel")
-					// INTEXT-200
 					.handle(Sftp.outboundAdapter(this.sftpSessionFactory, FileExistsMode.FAIL)
 									.useTemporaryFileName(false)
 									.remoteDirectory(this.sftpServer.getTargetSftpDirectory().getName())


### PR DESCRIPTION
Fixes GH-77 (https://github.com/spring-projects/spring-integration-java-dsl/issues/77)

Previously the `.route()` operator made the next `.channel()` in the `IntegrationFlow` as a `defaultOutputChannel` of the `Router`.
According to the user experience that doesn't sound reasonable to make such a decision unconditional.

* Remove logic to inject the next channel as a `defaultOutputChannel` for the `Router`
* Introduce `.defaultOutputToParentFlow()` hook for the `AbstractRouterSpec` to make that injection possible
* Introduce `.defaultOutputChannel(MessageChannel|String)` into the `AbstractRouterSpec` to make a `defaultOutputChannel` configurable alongside with regular channel mapping
* Introduce `.defaultSubFlowMapping()` to allow to configure sub-flow for the default case when any other mapping hasn't passed
* A new logic for "default output" works the same way for regular router and `RecipientListRouter`
* The "output-to-parent-flow-from-sub-flow" logic remains the same
* Move the rest router test from the `IntegrationFlowTests` to `RouterTests`