### PR TITLE
INTEXT-228: Add new method for mail adapters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ ext {
 	slf4jVersion = '1.7.21'
 	springIntegrationVersion = project.hasProperty('siVersion') ? project.siVersion : '4.3.1.RELEASE'
 	springIntegrationKafkaVersion = '1.3.1.RELEASE'
-	springKafkaVersion = '1.0.2.RELEASE'
-	springBootVersion = '1.4.0.BUILD-SNAPSHOT'
+	springKafkaVersion = '1.0.3.RELEASE'
+	springBootVersion = '1.4.1.BUILD-SNAPSHOT'
 	testNgVersion = '6.8.21'
 	tomcatVersion = '8.5.2'
 

--- a/src/main/java/org/springframework/integration/dsl/mail/ImapMailInboundChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/mail/ImapMailInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.dsl.mail;
 
 import org.springframework.integration.mail.ImapMailReceiver;
@@ -22,16 +23,21 @@ import org.springframework.integration.mail.SearchTermStrategy;
  * A {@link MailInboundChannelAdapterSpec} for IMAP.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ImapMailInboundChannelAdapterSpec
 		extends MailInboundChannelAdapterSpec<ImapMailInboundChannelAdapterSpec, ImapMailReceiver> {
 
 	ImapMailInboundChannelAdapterSpec() {
-		this.receiver = new ImapMailReceiver();
+		super(new ImapMailReceiver());
+	}
+
+	ImapMailInboundChannelAdapterSpec(ImapMailReceiver imapMailReceiver) {
+		super(imapMailReceiver, true);
 	}
 
 	ImapMailInboundChannelAdapterSpec(String url) {
-		this.receiver = new ImapMailReceiver(url);
+		super(new ImapMailReceiver(url), false);
 	}
 
 	/**
@@ -40,6 +46,7 @@ public class ImapMailInboundChannelAdapterSpec
 	 * @see ImapMailReceiver#setSearchTermStrategy(SearchTermStrategy)
 	 */
 	public ImapMailInboundChannelAdapterSpec searchTermStrategy(SearchTermStrategy searchTermStrategy) {
+		assertReceiver();
 		this.receiver.setSearchTermStrategy(searchTermStrategy);
 		return this;
 	}
@@ -50,6 +57,7 @@ public class ImapMailInboundChannelAdapterSpec
 	 * @see ImapMailReceiver#setShouldMarkMessagesAsRead(Boolean)
 	 */
 	public ImapMailInboundChannelAdapterSpec shouldMarkMessagesAsRead(boolean shouldMarkMessagesAsRead) {
+		assertReceiver();
 		this.receiver.setShouldMarkMessagesAsRead(shouldMarkMessagesAsRead);
 		return this;
 	}

--- a/src/main/java/org/springframework/integration/dsl/mail/Mail.java
+++ b/src/main/java/org/springframework/integration/dsl/mail/Mail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.dsl.mail;
 
 import org.springframework.integration.mail.ImapMailReceiver;
+import org.springframework.integration.mail.Pop3MailReceiver;
 
 /**
  * @author Gary Russell
@@ -29,6 +31,16 @@ public class Mail {
 
 	public static Pop3MailInboundChannelAdapterSpec pop3InboundAdapter() {
 		return new Pop3MailInboundChannelAdapterSpec();
+	}
+
+	/**
+	 * A {@link Pop3MailInboundChannelAdapterSpec} factory based on the provided {@link Pop3MailReceiver}.
+	 * @param pop3MailReceiver the {@link Pop3MailReceiver} to use.
+	 * @return the {@link Pop3MailInboundChannelAdapterSpec} instance.
+	 * @since 1.2
+	 */
+	public static Pop3MailInboundChannelAdapterSpec pop3InboundAdapter(Pop3MailReceiver pop3MailReceiver) {
+		return new Pop3MailInboundChannelAdapterSpec(pop3MailReceiver);
 	}
 
 	public static Pop3MailInboundChannelAdapterSpec pop3InboundAdapter(String url) {
@@ -48,24 +60,40 @@ public class Mail {
 		return new ImapMailInboundChannelAdapterSpec();
 	}
 
+	/**
+	 * An {@link ImapMailInboundChannelAdapterSpec} factory based on the provided {@link ImapMailReceiver}.
+	 * @param imapMailReceiver the {@link ImapMailReceiver} to use.
+	 * @return the {@link ImapMailInboundChannelAdapterSpec} instance.
+	 * @since 1.2
+	 */
+	public static ImapMailInboundChannelAdapterSpec imapInboundAdapter(ImapMailReceiver imapMailReceiver) {
+		return new ImapMailInboundChannelAdapterSpec(imapMailReceiver);
+	}
+
 	public static ImapMailInboundChannelAdapterSpec imapInboundAdapter(String url) {
 		return new ImapMailInboundChannelAdapterSpec(url);
 	}
 
 	public static ImapIdleChannelAdapterSpec imapIdleAdapter() {
-		return imapIdleAdapter(new ImapMailReceiver());
+		return new ImapIdleChannelAdapterSpec(new ImapMailReceiver());
 	}
 
 	public static ImapIdleChannelAdapterSpec imapIdleAdapter(String url) {
-		return imapIdleAdapter(new ImapMailReceiver(url));
+		return new ImapIdleChannelAdapterSpec(new ImapMailReceiver(url));
+	}
+
+	/**
+	 * An {@link ImapIdleChannelAdapterSpec} factory based on the provided {@link ImapMailReceiver}.
+	 * @param imapMailReceiver the {@link ImapMailReceiver} to use.
+	 * @return the {@link ImapIdleChannelAdapterSpec} instance.
+	 * @since 1.2
+	 */
+	public static ImapIdleChannelAdapterSpec imapIdleAdapter(ImapMailReceiver imapMailReceiver) {
+		return new ImapIdleChannelAdapterSpec(imapMailReceiver, true);
 	}
 
 	public static MailHeadersBuilder headers() {
 		return new MailHeadersBuilder();
-	}
-
-	private static ImapIdleChannelAdapterSpec imapIdleAdapter(ImapMailReceiver imapMailReceiver) {
-		return new ImapIdleChannelAdapterSpec(imapMailReceiver);
 	}
 
 }

--- a/src/main/java/org/springframework/integration/dsl/mail/Pop3MailInboundChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/dsl/mail/Pop3MailInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.dsl.mail;
 
 import org.springframework.integration.mail.Pop3MailReceiver;
@@ -21,24 +22,29 @@ import org.springframework.integration.mail.Pop3MailReceiver;
  * A {@link MailInboundChannelAdapterSpec} for POP3.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class Pop3MailInboundChannelAdapterSpec
 		extends MailInboundChannelAdapterSpec<Pop3MailInboundChannelAdapterSpec, Pop3MailReceiver> {
 
 	Pop3MailInboundChannelAdapterSpec() {
-		this.receiver = new Pop3MailReceiver();
+		super(new Pop3MailReceiver());
+	}
+
+	Pop3MailInboundChannelAdapterSpec(Pop3MailReceiver receiver) {
+		super(receiver, true);
 	}
 
 	Pop3MailInboundChannelAdapterSpec(String url) {
-		this.receiver = new Pop3MailReceiver(url);
+		super(new Pop3MailReceiver(url));
 	}
 
 	Pop3MailInboundChannelAdapterSpec(String host, String username, String password) {
-		this.receiver = new Pop3MailReceiver(host, username, password);
+		super(new Pop3MailReceiver(host, username, password));
 	}
 
 	Pop3MailInboundChannelAdapterSpec(String host, int port, String username, String password) {
-		this.receiver = new Pop3MailReceiver(host, port, username, password);
+		super(new Pop3MailReceiver(host, port, username, password));
 	}
 
 }

--- a/src/test/java/org/springframework/integration/dsl/test/mail/MailTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mail/MailTests.java
@@ -179,8 +179,11 @@ public class MailTests {
 		assertEquals("Foo <foo@bar>", headers.get(MailHeaders.TO, String[].class)[0]);
 		assertEquals("Bar <bar@baz>", headers.get(MailHeaders.FROM));
 		assertEquals("Test Email", headers.get(MailHeaders.SUBJECT));
-		// TODO until INT-4097
-		// assertEquals("foo\r\n", message.getPayload());
+		assertEquals("To: Foo <foo@bar>\r\n" +
+				 "From: Bar <bar@baz>\r\n" +
+				 "Subject: Test Email\r\n" +
+				 "\r\n" +
+				 "foo\r\n", message.getPayload());
 		this.imapIdleAdapter.stop();
 		assertFalse(TestUtils.getPropertyValue(this.imapIdleAdapter, "shouldReconnectAutomatically", Boolean.class));
 	}

--- a/src/test/java/org/springframework/integration/dsl/test/mail/MailTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mail/MailTests.java
@@ -51,9 +51,9 @@ import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageProducers;
 import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.mail.Mail;
-import org.springframework.integration.dsl.test.mail.PoorMansMailServer.ImapServer;
-import org.springframework.integration.dsl.test.mail.PoorMansMailServer.Pop3Server;
-import org.springframework.integration.dsl.test.mail.PoorMansMailServer.SmtpServer;
+import org.springframework.integration.dsl.test.mail.TestMailServer.ImapServer;
+import org.springframework.integration.dsl.test.mail.TestMailServer.Pop3Server;
+import org.springframework.integration.dsl.test.mail.TestMailServer.SmtpServer;
 import org.springframework.integration.mail.ImapIdleChannelAdapter;
 import org.springframework.integration.mail.MailHeaders;
 import org.springframework.integration.mail.support.DefaultMailHeaderMapper;
@@ -68,7 +68,6 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.util.SocketUtils;
 
 /**
  * @author Gary Russell
@@ -79,27 +78,20 @@ import org.springframework.util.SocketUtils;
 @DirtiesContext
 public class MailTests {
 
-	private final static int smtpPort = SocketUtils.findAvailableTcpPort();
+	private final static SmtpServer smtpServer = TestMailServer.smtp(0);
 
-	private final static SmtpServer smtpServer = PoorMansMailServer.smtp(smtpPort);
+	private final static Pop3Server pop3Server = TestMailServer.pop3(0);
 
-	private final static int pop3Port = SocketUtils.findAvailableTcpPort(smtpPort + 1);
+	private final static ImapServer imapServer = TestMailServer.imap(0);
 
-	private final static Pop3Server pop3Server = PoorMansMailServer.pop3(pop3Port);
-
-	private final static int imapPort = SocketUtils.findAvailableTcpPort(pop3Port + 1);
-
-	private final static ImapServer imapServer = PoorMansMailServer.imap(imapPort);
-
-	private final static int imapIdlePort = SocketUtils.findAvailableTcpPort(imapPort + 1);
-
-	private final static ImapServer imapIdleServer = PoorMansMailServer.imap(imapIdlePort);
+	private final static ImapServer imapIdleServer = TestMailServer.imap(0);
 
 
 	@BeforeClass
 	public static void setup() throws InterruptedException {
 		int n = 0;
-		while (n++ < 100 && (!smtpServer.isListening() || !pop3Server.isListening() || !imapServer.isListening())) {
+		while (n++ < 100 && (!smtpServer.isListening() || !pop3Server.isListening()
+				|| !imapServer.isListening()) || !imapIdleServer.isListening()) {
 			Thread.sleep(100);
 		}
 		assertTrue(n < 100);
@@ -162,8 +154,8 @@ public class MailTests {
 		Message<?> message = this.pop3Channel.receive(10000);
 		assertNotNull(message);
 		MessageHeaders headers = message.getHeaders();
-		assertEquals("foo@bar", headers.get(MailHeaders.TO, String[].class)[0]);
-		assertEquals("bar@baz", headers.get(MailHeaders.FROM));
+		assertEquals("Foo <foo@bar>", headers.get(MailHeaders.TO, String[].class)[0]);
+		assertEquals("Bar <bar@baz>", headers.get(MailHeaders.FROM));
 		assertEquals("Test Email", headers.get(MailHeaders.SUBJECT));
 		assertEquals("foo\r\n", message.getPayload());
 	}
@@ -173,8 +165,8 @@ public class MailTests {
 		Message<?> message = this.imapChannel.receive(10000);
 		assertNotNull(message);
 		MimeMessage mm = (MimeMessage) message.getPayload();
-		assertEquals("foo@bar", mm.getRecipients(RecipientType.TO)[0].toString());
-		assertEquals("bar@baz", mm.getFrom()[0].toString());
+		assertEquals("Foo <foo@bar>", mm.getRecipients(RecipientType.TO)[0].toString());
+		assertEquals("Bar <bar@baz>", mm.getFrom()[0].toString());
 		assertEquals("Test Email", mm.getSubject());
 		assertEquals("foo\r\n", mm.getContent());
 	}
@@ -183,11 +175,12 @@ public class MailTests {
 	public void testImapIdle() throws Exception {
 		Message<?> message = this.imapIdleChannel.receive(10000);
 		assertNotNull(message);
-		MimeMessage mm = (MimeMessage) message.getPayload();
-		assertEquals("foo@bar", mm.getRecipients(RecipientType.TO)[0].toString());
-		assertEquals("bar@baz", mm.getFrom()[0].toString());
-		assertEquals("Test Email", mm.getSubject());
-		assertEquals("foo\r\n", mm.getContent());
+		MessageHeaders headers = message.getHeaders();
+		assertEquals("Foo <foo@bar>", headers.get(MailHeaders.TO, String[].class)[0]);
+		assertEquals("Bar <bar@baz>", headers.get(MailHeaders.FROM));
+		assertEquals("Test Email", headers.get(MailHeaders.SUBJECT));
+		// TODO until INT-4097
+		// assertEquals("foo\r\n", message.getPayload());
 		this.imapIdleAdapter.stop();
 		assertFalse(TestUtils.getPropertyValue(this.imapIdleAdapter, "shouldReconnectAutomatically", Boolean.class));
 	}
@@ -204,7 +197,7 @@ public class MailTests {
 							.from("foo@bar")
 							.toFunction(m -> new String[] {"bar@baz"}))
 					.handleWithAdapter(h -> h.mail("localhost")
-									.port(smtpPort)
+									.port(smtpServer.getPort())
 									.credentials("user", "pw")
 									.protocol("smtp")
 									.javaMailProperties(p -> p.put("mail.debug", "false")),
@@ -215,7 +208,7 @@ public class MailTests {
 		@Bean
 		public IntegrationFlow pop3MailFlow() {
 			return IntegrationFlows
-					.from(s -> s.pop3("localhost", pop3Port, "user", "pw")
+					.from(s -> s.pop3("localhost", pop3Server.getPort(), "user", "pw")
 									.javaMailProperties(p -> p.put("mail.debug", "false"))
 									.headerMapper(mailHeaderMapper()),
 							e -> e.autoStartup(true).poller(p -> p.fixedDelay(1000)))
@@ -228,7 +221,7 @@ public class MailTests {
 		@Bean
 		public IntegrationFlow imapMailFlow() {
 			return IntegrationFlows
-					.from(s -> s.imap("imap://user:pw@localhost:" + imapPort + "/INBOX")
+					.from(s -> s.imap("imap://user:pw@localhost:" + imapServer.getPort() + "/INBOX")
 									.searchTermStrategy(this::fromAndNotSeenTerm)
 									.javaMailProperties(p -> p.put("mail.debug", "false")),
 							e -> e.autoStartup(true)
@@ -240,11 +233,13 @@ public class MailTests {
 		@Bean
 		public IntegrationFlow imapIdleFlow() {
 			return IntegrationFlows
-					.from((MessageProducers mp) -> mp.imap("imap://user:pw@localhost:" + imapIdlePort + "/INBOX")
+					.from((MessageProducers mp) ->
+							mp.imap("imap://user:pw@localhost:" + imapIdleServer.getPort() + "/INBOX")
 							.searchTermStrategy(this::fromAndNotSeenTerm)
 							.javaMailProperties(p -> p.put("mail.debug", "false")
 									.put("mail.imap.connectionpoolsize", "5"))
-							.shouldReconnectAutomatically(false))
+							.shouldReconnectAutomatically(false)
+							.headerMapper(mailHeaderMapper()))
 					.channel(MessageChannels.queue("imapIdleChannel"))
 					.get();
 		}

--- a/src/test/java/org/springframework/integration/dsl/test/mail/TestMailServer.java
+++ b/src/test/java/org/springframework/integration/dsl/test/mail/TestMailServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.dsl.test.mail;
 
 import java.io.BufferedReader;
@@ -29,13 +30,13 @@ import java.util.concurrent.Executors;
 
 import javax.net.ServerSocketFactory;
 
-import org.apache.sshd.common.util.Base64;
+import org.springframework.util.Base64Utils;
 
 /**
  * @author Gary Russell
  *
  */
-public class PoorMansMailServer {
+public class TestMailServer {
 
 	public static SmtpServer smtp(int port) {
 		try {
@@ -103,13 +104,13 @@ public class PoorMansMailServer {
 						}
 						else if (line.contains("dXNlcg==")) { // base64 'user'
 							sb.append("user:");
-							sb.append((new String(new Base64().decode(line.getBytes()))));
+							sb.append((new String(Base64Utils.decode(line.getBytes()))));
 							sb.append("\n");
 							write("334 UGFzc3dvcmQ6");
 						}
 						else if (line.contains("cHc=")) { // base64 'pw'
 							sb.append("password:");
-							sb.append((new String(new Base64().decode(line.getBytes()))));
+							sb.append((new String(Base64Utils.decode(line.getBytes()))));
 							sb.append("\n");
 							write("235");
 						}
@@ -270,14 +271,13 @@ public class PoorMansMailServer {
 							write("* 1 FETCH (RFC822.SIZE 6909 INTERNALDATE \"27-May-2013 09:45:41 +0000\" "
 									+ "FLAGS (\\Seen) "
 									+ "ENVELOPE (\"Mon, 27 May 2013 15:14:49 +0530\" "
-									+ "\"Test Email\" ((\"Foo\" NIL \"foo\" \"bar.tv\")) "
+									+ "\"Test Email\" ((\"Bar\" NIL \"bar\" \"baz\")) "
 									+ "((\"Foo\" NIL \"foo\" \"bar.tv\")) "
 									+ "((\"Foo\" NIL \"foo\" \"bar.tv\")) "
-									+ "((\"Bar\" NIL \"bar\" \"baz.net\")) NIL NIL "
+									+ "((\"Foo\" NIL \"foo\" \"bar\")) NIL NIL "
 									+ "\"<4DA0A7E4.3010506@baz.net>\" "
 									+ "\"<CACVnpJkAUUfa3d_-4GNZW2WpxbB39tBCHC=T0gc7hty6dOEHcA@foo.bar.com>\") "
-									+ "BODYSTRUCTURE (\"TEXT\" \"PLAIN\" (\"CHARSET\" \"ISO-8859-1\") NIL NIL "
-									+ "\"7BIT\" 1176 43)))");
+									+ "BODYSTRUCTURE (\"TEXT\" \"PLAIN\" (\"CHARSET\" \"ISO-8859-1\") NIL NIL \"7BIT\" 1176 43)))");
 							write(tag + "OK FETCH completed");
 						}
 						else if (line.contains("STORE 1 +FLAGS (\\Flagged)")) {
@@ -343,6 +343,10 @@ public class PoorMansMailServer {
 			exec.execute(this);
 		}
 
+		public int getPort() {
+			return this.socket.getLocalPort();
+		}
+
 		public boolean isListening() {
 			return listening;
 		}
@@ -378,7 +382,8 @@ public class PoorMansMailServer {
 
 		public abstract class MailHandler implements Runnable {
 
-			protected static final String MESSAGE = "To: foo@bar\r\nFrom: bar@baz\r\nSubject: Test Email\r\n\r\nfoo";
+			protected static final String MESSAGE =
+					"To: Foo <foo@bar>\r\nFrom: Bar <bar@baz>\r\nSubject: Test Email\r\n\r\nfoo";
 
 			protected final Socket socket;
 
@@ -416,7 +421,7 @@ public class PoorMansMailServer {
 
 	}
 
-	private PoorMansMailServer() {
+	private TestMailServer() {
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-228

Starting with SI-4.3 there are some new feature for mail adapters.

* Add `headerMapper` and other options for mail adapters
* Expose more `Mail` factory methods to let to inject an external `MailReceiver` to make configuration version-independent