### PR TITLE
GH-104: Disallow scope for `IntegrationFlow`

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
@@ -33,7 +32,7 @@ import org.springframework.integration.dsl.core.EndpointSpec;
 */
 public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle {
 
-	private final Set<Object> integrationComponents;
+	private final List<Object> integrationComponents;
 
 	private final List<SmartLifecycle> lifecycles = new LinkedList<SmartLifecycle>();
 
@@ -43,7 +42,7 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 
 	@SuppressWarnings("unchecked")
 	StandardIntegrationFlow(Set<Object> integrationComponents) {
-		this.integrationComponents = new LinkedHashSet<Object>(integrationComponents);
+		this.integrationComponents = new LinkedList<Object>(integrationComponents);
 		for (Object integrationComponent : integrationComponents) {
 			if (integrationComponent instanceof SmartLifecycle) {
 				this.lifecycles.add((SmartLifecycle) integrationComponent);
@@ -64,7 +63,7 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 		return this.registerComponents;
 	}
 
-	public Set<Object> getIntegrationComponents() {
+	public List<Object> getIntegrationComponents() {
 		return this.integrationComponents;
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.dsl.config;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -129,7 +130,7 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 		boolean registerSingleton = flow.isRegisterComponents();
 
 
-		List<Object> integrationComponents = flow.getIntegrationComponents();
+		List<Object> integrationComponents = new ArrayList<Object>(flow.getIntegrationComponents());
 		for (int i = 0; i < integrationComponents.size(); i++) {
 			Object component = integrationComponents.get(i);
 			if (component instanceof ConsumerEndpointSpec) {
@@ -223,7 +224,8 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 					}
 				}
 			}
-			}
+		}
+		flow.setIntegrationComponents(integrationComponents);
 		return flow;
 	}
 

--- a/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -30,8 +30,6 @@ import org.springframework.context.Lifecycle;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.StandardIntegrationFlow;
-import org.springframework.integration.dsl.support.FixedSubscriberChannelPrototype;
-import org.springframework.integration.dsl.support.MessageChannelReference;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -125,7 +123,7 @@ public final class IntegrationFlowContext implements BeanFactoryAware {
 	 */
 	public void register(String flowId, IntegrationFlow integrationFlow, boolean autoStartup) {
 		IntegrationFlow theFlow = (IntegrationFlow) this.beanFactory.initializeBean(integrationFlow, flowId);
-		this.beanFactory.registerSingleton(flowId, theFlow);
+//		this.beanFactory.registerSingleton(flowId, theFlow);
 
 		if (autoStartup) {
 			if (theFlow instanceof Lifecycle) {
@@ -174,20 +172,12 @@ public final class IntegrationFlowContext implements BeanFactoryAware {
 	public MessagingTemplate messagingTemplateFor(String flowId) {
 		MessageChannel channel = this.flowInputChannelCache.get(flowId);
 		if (channel == null) {
-			Object o = this.beanFactory.getBean(flowId);
+			Object o = this.registry.get(flowId);
 			if (o instanceof StandardIntegrationFlow) {
 				StandardIntegrationFlow integrationFlow = (StandardIntegrationFlow) o;
 				Object next = integrationFlow.getIntegrationComponents().iterator().next();
 				if (next instanceof MessageChannel) {
 					channel = (MessageChannel) next;
-					if (channel instanceof MessageChannelReference) {
-						channel = this.beanFactory.getBean(((MessageChannelReference) channel).getName(),
-								MessageChannel.class);
-					}
-					else if (channel instanceof FixedSubscriberChannelPrototype) {
-						channel = this.beanFactory.getBean(((FixedSubscriberChannelPrototype) channel).getName(),
-								MessageChannel.class);
-					}
 					this.flowInputChannelCache.put(flowId, channel);
 				}
 				else {

--- a/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -123,7 +123,7 @@ public final class IntegrationFlowContext implements BeanFactoryAware {
 	 */
 	public void register(String flowId, IntegrationFlow integrationFlow, boolean autoStartup) {
 		IntegrationFlow theFlow = (IntegrationFlow) this.beanFactory.initializeBean(integrationFlow, flowId);
-//		this.beanFactory.registerSingleton(flowId, theFlow);
+		this.beanFactory.registerSingleton(flowId, theFlow);
 
 		if (autoStartup) {
 			if (theFlow instanceof Lifecycle) {
@@ -155,8 +155,8 @@ public final class IntegrationFlowContext implements BeanFactoryAware {
 			this.flowInputChannelCache.remove(flowId);
 		}
 		else {
-			throw new IllegalStateException("Only manually registered IntegrationFlows can be removed. " +
-					"But [" + flowId + "] ins't one of them.");
+			throw new IllegalStateException("Only manually registered IntegrationFlows can be removed. "
+					+ "But [" + flowId + "] ins't one of them.");
 		}
 	}
 

--- a/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/flowservices/FlowServiceTests.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -143,10 +144,10 @@ public class FlowServiceTests {
 	@Component
 	public static class MyFlowAdapter extends IntegrationFlowAdapter {
 
-		private final AtomicBoolean invoked = new AtomicBoolean();
+		private final AtomicReference<Date> executionDate = new AtomicReference<>(new Date());
 
-		public Date nextExecutionTime(TriggerContext triggerContext) {
-			return this.invoked.getAndSet(true) ? null : new Date();
+		private Date nextExecutionTime(TriggerContext triggerContext) {
+			return this.executionDate.getAndSet(null);
 		}
 
 		@Override

--- a/src/test/java/org/springframework/integration/dsl/test/handlers/MessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/handlers/MessageHandlerTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
@@ -53,6 +54,7 @@ public class MessageHandlerTests {
 	}
 
 	@Configuration
+	@EnableIntegration
 	public static class InvalidReuseOfAbstractMessageProducingHandlerContext {
 
 		@Bean

--- a/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
@@ -33,11 +33,9 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.BeanCreationNotAllowedException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessagingTemplate;
@@ -53,6 +51,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.context.annotation.RequestScope;
 
 /**
  * @author Artem Bilan
@@ -202,7 +201,7 @@ public class ManualFlowTests {
 	public static class InvalidIntegrationFlowScopeConfiguration {
 
 		@Bean
-		@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+		@RequestScope
 		public IntegrationFlow wrongScopeFlow() {
 			return flow -> flow.bridge(null);
 		}

--- a/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
@@ -112,7 +112,8 @@ public class ManualFlowTests {
 				flow.bridge(null);
 			}
 
-		};
+		}
+		;
 
 		IntegrationFlow testFlow = new MyIntegrationFlow();
 
@@ -195,7 +196,11 @@ public class ManualFlowTests {
 							e.poller(p ->
 									p.trigger(ctx -> this.nextExecutionTime.getAndSet(null))))
 					.channel(c -> c.queue("flowAdapterOutput"));
-	
+
+		}
+
+	}
+
 	@Configuration
 	@EnableIntegration
 	public static class InvalidIntegrationFlowScopeConfiguration {
@@ -206,4 +211,5 @@ public class ManualFlowTests {
 			return flow -> flow.bridge(null);
 		}
 
-	}}
+	}
+}


### PR DESCRIPTION
Fixes GH-104 (https://github.com/spring-projects/spring-integration-java-dsl/issues/104)

Since `IntegrationFlow` is just a logical container for the rest Integration component in the flow definition,
it doesn't not make any sense to have it in the `scope`. Just because all those components are registered as singletons for their proper stateless lifecycle and logic

* Throw `BeanCreationNotAllowedException` if `IntegrationFlow` bean definition is in not singleton scope.