### PR TITLE
GH-120: Reduce scope filter to IntegrationFlow

### DIFF
--- a/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
@@ -112,7 +112,7 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 			}
 		}
 
-		for (String beanName : this.beanFactory.getBeanDefinitionNames()) {
+		for (String beanName : this.beanFactory.getBeanNamesForType(IntegrationFlow.class)) {
 			if (this.beanFactory.containsBeanDefinition(beanName)) {
 				String scope = this.beanFactory.getBeanDefinition(beanName).getScope();
 				if (StringUtils.hasText(scope) && !BeanDefinition.SCOPE_SINGLETON.equals(scope)) {

--- a/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
@@ -187,6 +187,12 @@ public class ManualFlowTests {
 	@EnableIntegration
 	public static class RootConfiguration {
 
+		@Bean
+		@RequestScope
+		public Date foo() {
+			return new Date();
+		}
+
 	}
 
 	private static class MyFlowAdapter extends IntegrationFlowAdapter {


### PR DESCRIPTION
Fixes GH-120 (https://github.com/spring-projects/spring-integration-java-dsl/issues/120)

The previous code disallowed any scoped beans.
The logic must be based only on the `IntegrationFlow` beans.