### PR TITLE
GH-128: Exclude `KafkaTests` from IO build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,13 +191,20 @@ dependencies {
 [compileJava, compileTestJava]*.options*.compilerArgs = ['-Xlint:all,-options,-processing']
 
 test {
-	// suppress all console output during testing unless running `gradle -i`
-	logging.captureStandardOutput(LogLevel.INFO)
-	maxHeapSize = "1024m"
 	jacoco {
 		append = false
 		destinationFile = file("$buildDir/jacoco.exec")
 	}
+}
+
+tasks.withType(Test).all {
+	// suppress all console output during testing unless running `gradle -i`
+	logging.captureStandardOutput(LogLevel.INFO)
+	maxHeapSize = "1024m"
+	if (name == 'springIoJdk8Test') {
+		exclude '**/*KafkaTests*'
+	}
+
 }
 
 checkstyle {


### PR DESCRIPTION
Fixes GH-128 (https://github.com/spring-projects/spring-integration-java-dsl/issues/128)

To pursue Kafka 0.8, 0.9, 0.10 support/compatibility we should exclude `KafkaTests` from `springIoJdk8Test`
In this case we simply comply against SI-Kafka-1.3 (Kafka 0.8 support) and Spring Kafka 1.0 (Kafka 0.9), but we don't test it at all, because we don't have Kafka 0.10 support yet.
The Kafka 0.10 support can be achieve with direct Spring Integration Kafka 2.1 usage