### PR TITLE
GH-125: Improve and fix `IntegrationFlowContext`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,7 @@ jacocoTestReport {
 	}
 }
 
+check.dependsOn javadoc
 build.dependsOn jacocoTestReport
 
 task sourcesJar(type: Jar) {

--- a/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -72,6 +73,8 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 
 	private ConfigurableListableBeanFactory beanFactory;
 
+	private AutowiredAnnotationBeanPostProcessor autowiredAnnotationBeanPostProcessor;
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		Assert.isInstanceOf(ConfigurableListableBeanFactory.class, beanFactory,
@@ -80,6 +83,8 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 		);
 
 		this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;
+		this.autowiredAnnotationBeanPostProcessor = new AutowiredAnnotationBeanPostProcessor();
+		this.autowiredAnnotationBeanPostProcessor.setBeanFactory(this.beanFactory);
 	}
 
 	@Override
@@ -268,13 +273,14 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 		if (component instanceof ApplicationListener) {
 			this.applicationListeners.add((ApplicationListener<?>) component);
 		}
+		this.beanFactory.initializeBean(component, beanName);
+		this.autowiredAnnotationBeanPostProcessor.processInjection(component);
 		if (registerSingleton) {
 			this.beanFactory.registerSingleton(beanName, component);
 			if (parentName != null) {
 				this.beanFactory.registerDependentBean(parentName, beanName);
 			}
 		}
-		this.beanFactory.initializeBean(component, beanName);
 	}
 
 	private String generateBeanName(Object instance) {
@@ -282,7 +288,7 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 			return ((NamedComponent) instance).getComponentName();
 		}
 		String generatedBeanName = instance.getClass().getName();
-		String id = instance.getClass().getName();
+		String id = generatedBeanName;
 		int counter = -1;
 		while (counter == -1 || this.beanFactory.containsBean(id)) {
 			counter++;

--- a/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
+++ b/src/main/java/org/springframework/integration/dsl/config/IntegrationFlowBeanPostProcessor.java
@@ -273,8 +273,8 @@ public class IntegrationFlowBeanPostProcessor implements BeanPostProcessor, Bean
 		if (component instanceof ApplicationListener) {
 			this.applicationListeners.add((ApplicationListener<?>) component);
 		}
-		this.beanFactory.initializeBean(component, beanName);
 		this.autowiredAnnotationBeanPostProcessor.processInjection(component);
+		this.beanFactory.initializeBean(component, beanName);
 		if (registerSingleton) {
 			this.beanFactory.registerSingleton(beanName, component);
 			if (parentName != null) {

--- a/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -118,9 +118,9 @@ public final class IntegrationFlowContext implements BeanFactoryAware {
 			beanName = generateBeanName(bean, parentName);
 		}
 
+		this.autowiredAnnotationBeanPostProcessor.processInjection(bean);
 		bean = this.beanFactory.initializeBean(bean, beanName);
 		this.beanFactory.registerSingleton(beanName, bean);
-		this.autowiredAnnotationBeanPostProcessor.processInjection(bean);
 		if (parentName != null) {
 			this.beanFactory.registerDependentBean(parentName, beanName);
 		}

--- a/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowRegistration.java
+++ b/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowRegistration.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.context;
+
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.Lifecycle;
+import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.StandardIntegrationFlow;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * Instances of this classes are returned as a result of
+ * {@link IntegrationFlowContext#registration(IntegrationFlow)} invocation
+ * and provide an API for some useful {@link IntegrationFlow} options and its lifecycle.
+ *
+ * @author Artem Bilan
+ * @since 1.2
+ *
+ * @see IntegrationFlowContext
+ */
+public class IntegrationFlowRegistration {
+
+	private IntegrationFlow integrationFlow;
+
+	private IntegrationFlowContext integrationFlowContext;
+
+	private String id;
+
+	private MessageChannel inputChannel;
+
+	private MessagingTemplate messagingTemplate;
+
+	private ConfigurableListableBeanFactory beanFactory;
+
+	IntegrationFlowRegistration(IntegrationFlow integrationFlow) {
+		this.integrationFlow = integrationFlow;
+	}
+
+	void setBeanFactory(ConfigurableListableBeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
+	}
+
+	void setIntegrationFlowContext(IntegrationFlowContext integrationFlowContext) {
+		this.integrationFlowContext = integrationFlowContext;
+	}
+
+	void setId(String id) {
+		this.id = id;
+	}
+
+	void setIntegrationFlow(IntegrationFlow integrationFlow) {
+		this.integrationFlow = integrationFlow;
+	}
+
+	public String getId() {
+		return this.id;
+	}
+
+	public IntegrationFlow getIntegrationFlow() {
+		return this.integrationFlow;
+	}
+
+	public MessageChannel getInputChannel() {
+		if (this.inputChannel == null) {
+			synchronized (this) {
+				if (this.inputChannel == null) {
+					if (this.integrationFlow instanceof StandardIntegrationFlow) {
+						StandardIntegrationFlow integrationFlow = (StandardIntegrationFlow) this.integrationFlow;
+						Object next = integrationFlow.getIntegrationComponents().iterator().next();
+						if (next instanceof MessageChannel) {
+							this.inputChannel = (MessageChannel) next;
+						}
+						else {
+							throw new IllegalStateException("The 'IntegrationFlow' [" + integrationFlow + "] " +
+									"doesn't start with 'MessageChannel' for direct message sending.");
+						}
+					}
+					else {
+						throw new IllegalStateException("Only 'StandardIntegrationFlow' instances " +
+								"(e.g. extracted from 'IntegrationFlow' Lambdas) can be used " +
+								"for direct 'send' operation. " +
+								"But [" + this.integrationFlow + "] ins't one of them.\n" +
+								"Consider 'BeanFactory.getBean()' usage for sending messages " +
+								"to the required 'MessageChannel'.");
+					}
+				}
+			}
+		}
+		return this.inputChannel;
+	}
+
+	/**
+	 * Obtain a {@link MessagingTemplate} with its default destination set to the input channel
+	 * of the {@link IntegrationFlow}.
+	 * <p> Any {@link IntegrationFlow} bean (not only manually registered) can be used for this method.
+	 * <p> If {@link IntegrationFlow} doesn't start with the {@link MessageChannel}, the
+	 * {@link IllegalStateException} is thrown.
+	 * @return the {@link MessagingTemplate} instance
+	 */
+	public MessagingTemplate getMessagingTemplate() {
+		if (this.messagingTemplate == null) {
+			synchronized (this) {
+				if (this.messagingTemplate == null) {
+					this.messagingTemplate = new MessagingTemplate(getInputChannel()) {
+
+						@Override
+						public Message<?> receive() {
+							return receiveAndConvert(Message.class);
+						}
+
+						@Override
+						public <T> T receiveAndConvert(Class<T> targetClass) {
+							throw new UnsupportedOperationException("The 'receive()/receiveAndConvert()' " +
+									"isn't supported on the 'IntegrationFlow' input channel.");
+						}
+
+					};
+					this.messagingTemplate.setBeanFactory(this.beanFactory);
+				}
+			}
+		}
+		return this.messagingTemplate;
+	}
+
+	public void start() {
+		if (this.integrationFlow instanceof Lifecycle) {
+			((Lifecycle) this.integrationFlow).start();
+		}
+		else {
+			throw new IllegalStateException("For 'autoStartup' mode the 'IntegrationFlow' " +
+					"must be an instance of 'Lifecycle'.\n" +
+					"Consider to implement it for [" + this.integrationFlow + "]. " +
+					"Or start dependent components on their own.");
+		}
+	}
+
+	public void stop() {
+		if (this.integrationFlow instanceof Lifecycle) {
+			((Lifecycle) this.integrationFlow).stop();
+		}
+	}
+
+	/**
+	 * Destroy the {@link IntegrationFlow} bean (as well as all its dependant beans)
+	 * and clean up all the local cache for it.
+	 */
+	public void destroy() {
+		this.integrationFlowContext.remove(this.id);
+	}
+
+}

--- a/src/test/java/org/springframework/integration/dsl/test/amqp/AmqpTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/amqp/AmqpTests.java
@@ -16,11 +16,9 @@
 
 package org.springframework.integration.dsl.test.amqp;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -127,17 +125,13 @@ public class AmqpTests {
 	}
 
 	@Test
-	public void test41() {
-		try {
-			IntegrationFlowBuilder flow = IntegrationFlows.from(Amqp.channel("test41", this.rabbitConnectionFactory)
-					.autoStartup(false)
-					.templateChannelTransacted(true));
-			assertTrue(TestUtils.getPropertyValue(flow, "currentMessageChannel.amqpTemplate.transactional",
-					Boolean.class));
-		}
-		catch (UnsupportedOperationException e) {
-			assertThat(e.getMessage(), containsString("Requires Spring Integration 4.1 or higher."));
-		}
+	public void testTemplateChannelTransacted() {
+		IntegrationFlowBuilder flow = IntegrationFlows.from(Amqp.channel("testTemplateChannelTransacted",
+				this.rabbitConnectionFactory)
+				.autoStartup(false)
+				.templateChannelTransacted(true));
+		assertTrue(TestUtils.getPropertyValue(flow, "currentMessageChannel.amqpTemplate.transactional",
+				Boolean.class));
 	}
 
 	@Autowired
@@ -247,12 +241,12 @@ public class AmqpTests {
 		@Bean
 		public AbstractAmqpChannel unitChannel(ConnectionFactory rabbitConnectionFactory) {
 			return Amqp.pollableChannel(rabbitConnectionFactory)
-							.queueName("foo")
-							.channelTransacted(true)
-							.extractPayload(true)
-							.inboundHeaderMapper(mapperIn())
-							.outboundHeaderMapper(mapperOut())
-							.defaultDeliveryMode(MessageDeliveryMode.NON_PERSISTENT)
+					.queueName("foo")
+					.channelTransacted(true)
+					.extractPayload(true)
+					.inboundHeaderMapper(mapperIn())
+					.outboundHeaderMapper(mapperOut())
+					.defaultDeliveryMode(MessageDeliveryMode.NON_PERSISTENT)
 					.get();
 		}
 

--- a/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
@@ -21,10 +21,12 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -44,6 +46,8 @@ import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowAdapter;
 import org.springframework.integration.dsl.IntegrationFlowDefinition;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
+import org.springframework.integration.dsl.context.IntegrationFlowRegistration;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
@@ -77,11 +81,22 @@ public class ManualFlowTests {
 						.poller(p -> p
 								.fixedDelay(10)
 								.maxMessagesPerPoll(1)
-								.receiveTimeout(10)));
+								.receiveTimeout(10)))
+				.handle(new BeanFactoryHandler());
 
-		String flowId = this.integrationFlowContext.register(myFlow);
+		BeanFactoryHandler additionalBean = new BeanFactoryHandler();
+		IntegrationFlowRegistration flowRegistration =
+				this.integrationFlowContext.registration(myFlow)
+						.addBean(additionalBean)
+						.register();
 
-		MessagingTemplate messagingTemplate = this.integrationFlowContext.messagingTemplateFor(flowId);
+		BeanFactoryHandler bean =
+				this.beanFactory.getBean(flowRegistration.getId() + BeanFactoryHandler.class.getName() + "#0",
+						BeanFactoryHandler.class);
+		assertSame(additionalBean, bean);
+		assertSame(this.beanFactory, bean.beanFactory);
+
+		MessagingTemplate messagingTemplate = flowRegistration.getMessagingTemplate();
 		messagingTemplate.setReceiveTimeout(10000);
 
 		assertEquals("Hello, FOO", messagingTemplate.convertSendAndReceive("foo", String.class));
@@ -97,10 +112,10 @@ public class ManualFlowTests {
 			assertThat(e.getMessage(), containsString("The 'receive()/receiveAndConvert()' isn't supported"));
 		}
 
-		this.integrationFlowContext.remove(flowId);
+		flowRegistration.destroy();
 
-		assertFalse(this.beanFactory.containsBean(flowId));
-		assertFalse(this.beanFactory.containsBean(flowId + ".input"));
+		assertFalse(this.beanFactory.containsBean(flowRegistration.getId()));
+		assertFalse(this.beanFactory.containsBean(flowRegistration.getId() + ".input"));
 
 		ThreadPoolTaskScheduler taskScheduler = this.beanFactory.getBean(ThreadPoolTaskScheduler.class);
 		Thread.sleep(100);
@@ -122,10 +137,12 @@ public class ManualFlowTests {
 		IntegrationFlow testFlow = new MyIntegrationFlow();
 
 		// This is fine because we are not going to start it automatically.
-		assertNotNull(this.integrationFlowContext.register(testFlow, false));
+		assertNotNull(this.integrationFlowContext.registration(testFlow)
+				.autoStartup(false)
+				.register());
 
 		try {
-			this.integrationFlowContext.register(testFlow);
+			this.integrationFlowContext.registration(testFlow).register();
 			fail("IllegalStateException expected");
 		}
 		catch (Exception e) {
@@ -147,11 +164,13 @@ public class ManualFlowTests {
 	public void testDynamicSubFlow() {
 		PollableChannel resultChannel = new QueueChannel();
 
-		this.integrationFlowContext.register("dynamicFlow", flow -> flow
-				.publishSubscribeChannel(p -> p
+		this.integrationFlowContext.registration(flow ->
+				flow.publishSubscribeChannel(p -> p
 						.minSubscribers(1)
 						.subscribe(f -> f.channel(resultChannel))
-				));
+				))
+				.id("dynamicFlow")
+				.register();
 
 		this.integrationFlowContext.messagingTemplateFor("dynamicFlow").send(new GenericMessage<>("test"));
 
@@ -162,7 +181,7 @@ public class ManualFlowTests {
 
 	@Test
 	public void testDynamicAdapterFlow() {
-		this.integrationFlowContext.register(new MyFlowAdapter());
+		this.integrationFlowContext.registration(new MyFlowAdapter()).register();
 		PollableChannel resultChannel = this.beanFactory.getBean("flowAdapterOutput", PollableChannel.class);
 
 		Message<?> receive = resultChannel.receive(1000);
@@ -218,6 +237,19 @@ public class ManualFlowTests {
 		@RequestScope
 		public IntegrationFlow wrongScopeFlow() {
 			return flow -> flow.bridge(null);
+		}
+
+	}
+
+	private final class BeanFactoryHandler extends AbstractReplyProducingMessageHandler {
+
+		@Autowired
+		private BeanFactory beanFactory;
+
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			Objects.requireNonNull(this.beanFactory);
+			return requestMessage;
 		}
 
 	}

--- a/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
+++ b/src/test/java/org/springframework/integration/dsl/test/manualflow/ManualFlowTests.java
@@ -116,6 +116,7 @@ public class ManualFlowTests {
 
 		assertFalse(this.beanFactory.containsBean(flowRegistration.getId()));
 		assertFalse(this.beanFactory.containsBean(flowRegistration.getId() + ".input"));
+		assertFalse(this.beanFactory.containsBean(flowRegistration.getId() + BeanFactoryHandler.class.getName() + "#0"));
 
 		ThreadPoolTaskScheduler taskScheduler = this.beanFactory.getBean(ThreadPoolTaskScheduler.class);
 		Thread.sleep(100);


### PR DESCRIPTION
Fixes GH-125 (https://github.com/spring-projects/spring-integration-java-dsl/issues/125)

* Introduce `IntegrationFlowContext.IntegrationFlowRegistrationBuilder` for fluent API for multi-options
* Introduce `IntegrationFlowRegistration` as a result of registration for further management logic
* Add an option to register additional beans associated with the manually registered `IntegrationFlow`
* Fix `@Autowired` but in the `IntegrationFlowBeanPostProcessor`
* Reflect changes in the `ManualFlowTests`
* Add `check.dependsOn javadoc` configuration to the `build.gradle` since Checkstyle doesn't see `{@link}` problems