### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the [Spring Integration Contributor Guidelines](https://github.com/spring-pr
 
 # Resources
 
-For more information, please visit the Spring Integration website at: [http://projects.spring.io/spring-integration/](http://projects.spring.io/spring-integration/)
+For more information, please visit the Spring Integration website at: [https://projects.spring.io/spring-integration/](https://projects.spring.io/spring-integration/)
 
 Also:
 

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -14,8 +14,8 @@ This document is the API specification for Spring Integration Java DSL Extension
 
     <p>
         If you are interested in commercial training, consultancy, and
-        support for Spring Integration, please visit <a href="http://spring.io/" target="_top">
-        http://spring.io</a>
+        support for Spring Integration, please visit <a href="https://spring.io/" target="_top">
+        https://spring.io</a>
     </p>
 </div>
 </body>

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -4,13 +4,13 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/src/test/resources/org/springframework/integration/dsl/test/feed/sample.rss
+++ b/src/test/resources/org/springframework/integration/dsl/test/feed/sample.rss
@@ -1,7 +1,7 @@
 <rss version="2.0">
 <channel>
 <title>Spring Integration</title>
-<link>http://www.springsource.org/spring-integration</link>
+<link>https://www.springsource.org/spring-integration</link>
 <description>
 Spring Integration is a really cool framework
 </description>
@@ -11,16 +11,16 @@ All Rights Reserved.</copyright>
 <lastBuildDate>Tue, 12 Apr 2010 18:21:32 EST</lastBuildDate>
 <ttl>240</ttl>
 <image>
-<url>http://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png</url>
+<url>https://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png</url>
 <title>Spring Integration</title>
-<link>http://www.springsource.org/spring-integration</link>
+<link>https://www.springsource.org/spring-integration</link>
 </image>
 
 <item>
 <title>
 Spring Integration adapters
 </title>
-<link>http://www.springsource.org/extensions/se-sia</link>
+<link>https://www.springsource.org/extensions/se-sia</link>
 <description>
 Spring Integration adapters are realy cool
 </description>
@@ -31,7 +31,7 @@ Spring Integration adapters are realy cool
 <title>
 Spring Integration download
 </title>
-<link>http://www.springsource.com/products/spring-community-download</link>
+<link>https://www.springsource.com/products/spring-community-download</link>
 <description>
 Download Spring Integration
 </description>
@@ -42,7 +42,7 @@ Download Spring Integration
 <title>
 Check out Spring Integration forums
 </title>
-<link>http://forum.springsource.org/forumdisplay.php?f=42</link>
+<link>https://forum.spring.io/forumdisplay.php?f=42</link>
 <description>
 Spring Integration forums are awesome
 </description>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://projects.spring.io/spring-integration/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-integration/ ([https](https://projects.spring.io/spring-integration/) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://spring.io/ with 1 occurrences migrated to:  
  https://spring.io/ ([https](https://spring.io/) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://forum.springsource.org/forumdisplay.php?f=42 (301) with 1 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=42 ([https](https://forum.springsource.org/forumdisplay.php?f=42) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.com/products/spring-community-download with 1 occurrences migrated to:  
  https://www.springsource.com/products/spring-community-download ([https](https://www.springsource.com/products/spring-community-download) result 301).
* [ ] http://www.springsource.org/spring-integration with 2 occurrences migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).
* [ ] http://www.springsource.org/extensions/se-sia with 1 occurrences migrated to:  
  https://www.springsource.org/extensions/se-sia ([https](https://www.springsource.org/extensions/se-sia) result 302).
* [ ] http://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png with 1 occurrences migrated to:  
  https://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png ([https](https://www.springsource.org/sites/all/themes/dotorg09/images/dotorg09_logo.png) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 1 occurrences